### PR TITLE
Fix control button size rendering on mobile

### DIFF
--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -34,3 +34,8 @@
 .leaflet-control-locate.active a {
     background-image: url(images/locate_active.png);
 }
+
+.leaflet-touch .leaflet-control-locate a {
+    width: 27px;
+    height: 27px;
+}


### PR DESCRIPTION
Fixes the control button size as rendered on mobile web browsers.

The locate button is now the same size as the zoom in / out buttons.
Before the locate button was much smaller, and much harder to push with fat fingers.

Tested on Fennec (mobile firefox 15.0) and the default web-kit based browser on the Nokia n9 Meego phone.
