### PR TITLE
Stop locate after unchecking location button

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -63,13 +63,16 @@ L.Control.Locate = L.Control.extend({
             .on(link, 'click', function() {
                 _log('at location: ' + self._atLocation);
                 if (self._atLocation && self._active) {
+                    map.stopLocate();
                     removeVisualization();
                 } else {
+                    if(!self._active) {
+                        map.locate(self._locateOptions);
+                    }
                     self._active = true;
                     self._locateOnNextLocationFound = true;
                     if (!self._event) {
                         self._container.className = classNames + " requesting";
-                        map.locate(self._locateOptions);
                     } else {
                         visualizeLocation();
                     }


### PR DESCRIPTION
Map keeps locating position after unchecking location button. It should stop locate, because especially high accurary-mode consumes lot of battery.
