### PR TITLE
Update button style for touch devices (tested on android webview)

### DIFF
--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -3,25 +3,35 @@
     margin-top: 12px;
 }
 
+.leaflet-control-locate {
+    -moz-border-radius: 4px 4px 4px 4px;
+    -webkit-border-radius: 4px 4px 4px 4px;
+            border-radius: 4px 4px 4px 4px;
+	background-color: #f8f8f9;
+}
+	
 .leaflet-control-locate a {
     background-position: 50% 50%;
     background-repeat: no-repeat;
     display: block;
     width: 22px;
     height: 22px;
-
-    -moz-border-radius: 4px 4px 4px 4px;
-    -webkit-border-radius: 4px 4px 4px 4px;
-            border-radius: 4px 4px 4px 4px;
 }
 
-.leaflet-control-locate a:hover {
+.leaflet-control-locate:hover {
     background-color: #fff;
 }
 
+.leaflet-touch .leaflet-control-locate {
+	-webkit-border-radius: 7px 7px 7px 7px;
+	        border-radius: 7px 7px 7px 7px;
+	box-shadow: none;
+	border: 4px solid rgba(0,0,0,0.3);
+}
+
 .leaflet-touch .leaflet-control-locate a {
-    width: 27px;
-    height: 27px;
+    width: 30px;
+    height: 30px;
 }
 
 .leaflet-control-locate a {

--- a/src/L.Control.Locate.ie.css
+++ b/src/L.Control.Locate.ie.css
@@ -3,10 +3,10 @@
 	border: 3px solid #999;
 }
 
-.leaflet-control-locate a {
+.leaflet-control-locate {
 	background-color: #eee;
 }
 
-.leaflet-control-locate a:hover {
+.leaflet-control-locate:hover {
 	background-color: #fff;
 }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -51,7 +51,7 @@ L.Control.Locate = L.Control.extend({
         this._locateOnNextLocationFound = false;
         this._active = false;
 
-        var link = L.DomUtil.create('a', 'leaflet-bar-part', container);
+        var link = L.DomUtil.create('a', 'leaflet-control-locate-button', container);
         link.href = '#';
         link.title = this.options.title;
 


### PR DESCRIPTION
Fixes the styling for webkit touch device. 

Details : 
Uses the div instead of a for border-radius and color background (As is done for the standard leaflet Layers control)
Do not uses leaflet-bar-part class that breaks styling on touch devices and does not appear to be used in non touch devices.
