### PR TITLE
Respect map boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ L.control.locate({
     followMarkerStyle: {},
     metric: true,  // use metric or imperial units
     onLocationError: function(err) {alert(err.message)},  // define an error callback function
-    onLocationOutsideMapBounds:  function(context) {
+    onLocationOutsideMapBounds:  function(context) { // called when outside map boundaries
             alert(context.options.strings.outsideMapBoundsMsg);
-            return false;
-    }, // function called when outside map boundaries. Abort if returns False (default)
+    },
     setView: true, // automatically sets the map view to the user's location
     strings: {
         title: "Show me where I am",  // title of the locat control

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ L.control.locate({
     followMarkerStyle: {},
     metric: true,  // use metric or imperial units
     onLocationError: function(err) {alert(err.message)},  // define an error callback function
+    onLocationOutsideMapBounds: null, // function called when outside map boundaries. Abort if returns False (default)
     setView: true, // automatically sets the map view to the user's location
     strings: {
         title: "Show me where I am",  // title of the locat control
         popupText: You are within {distance} {unit} from this point,  // text to appear if user clicks on circle
+        outsideMapBoundsMsg: "You seem located outside the boundaries of the map" // default message for onLocationOutsideMapBounds
     }
     locateOptions: {}  // define location options e.g enableHighAccuracy: true
 }).addTo(map);

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ L.control.locate({
     followMarkerStyle: {},
     metric: true,  // use metric or imperial units
     onLocationError: function(err) {alert(err.message)},  // define an error callback function
-    onLocationOutsideMapBounds: null, // function called when outside map boundaries. Abort if returns False (default)
+    onLocationOutsideMapBounds:  function(context) {
+            alert(context.options.strings.outsideMapBoundsMsg);
+            return false;
+    }, // function called when outside map boundaries. Abort if returns False (default)
     setView: true, // automatically sets the map view to the user's location
     strings: {
         title: "Show me where I am",  // title of the locat control

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -32,7 +32,10 @@ L.Control.Locate = L.Control.extend({
         onLocationError: function(err) {
             alert(err.message);
         },
-        onLocationOutsideMapBounds: null,
+        onLocationOutsideMapBounds: function(e, message) {
+            alert(message);
+            return false;
+        },
         setView: true, // automatically sets the map view to the user's location
         strings: {
             title: "Show me where I am",
@@ -137,7 +140,8 @@ L.Control.Locate = L.Control.extend({
             if (self._locateOnNextLocationFound) {
                 if (map.options.maxBounds &&
                     !map.options.maxBounds.contains(self._event.latlng) &&
-                    !self.options.onLocationOutsideMapBounds(self._event)) {
+                    !self.options.onLocationOutsideMapBounds(self._event,
+                                            self.options.strings.outsideMapBoundsMsg)) {
                     // outside map boundaries
                     self._following = false;
                 } else {
@@ -209,16 +213,6 @@ L.Control.Locate = L.Control.extend({
 
             self._layer.clearLayers();
         };
-
-        var onLocationOutsideMapBounds = function(e) {
-            alert(self.options.strings.outsideMapBoundsMsg);
-            return false;
-        }
-
-        if (!this.options.onLocationOutsideMapBounds) {
-            // fall back to default if none provided
-            this.options.onLocationOutsideMapBounds = onLocationOutsideMapBounds;
-        }
 
         var onLocationError = function (err) {
             // ignore timeout error if the location is watched

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -32,8 +32,8 @@ L.Control.Locate = L.Control.extend({
         onLocationError: function(err) {
             alert(err.message);
         },
-        onLocationOutsideMapBounds: function(e, message) {
-            alert(message);
+        onLocationOutsideMapBounds: function(context) {
+            alert(context.options.strings.outsideMapBoundsMsg);
             return false;
         },
         setView: true, // automatically sets the map view to the user's location
@@ -81,7 +81,7 @@ L.Control.Locate = L.Control.extend({
             .on(link, 'click', L.DomEvent.preventDefault)
             .on(link, 'click', function() {
                 if (self._active && (map.getBounds().contains(self._event.latlng) || !self.options.setView ||
-                    (map.options.maxBounds && !map.options.maxBounds.contains(self._event.latlng)))) {
+                    isOutsideMapBounds() )) {
                     stopLocate();
                 } else {
                     if (self.options.setView) {
@@ -135,15 +135,16 @@ L.Control.Locate = L.Control.extend({
             visualizeLocation();
         };
 
+        var isOutsideMapBounds = function () {
+            return map.options.maxBounds &&
+                   !map.options.maxBounds.contains(self._event.latlng);
+        }
+
         var visualizeLocation = function() {
             var radius = self._event.accuracy / 2;
             if (self._locateOnNextLocationFound) {
-                if (map.options.maxBounds &&
-                    !map.options.maxBounds.contains(self._event.latlng) &&
-                    !self.options.onLocationOutsideMapBounds(self._event,
-                                            self.options.strings.outsideMapBoundsMsg)) {
-                    // outside map boundaries
-                    self._following = false;
+                if (isOutsideMapBounds()) {
+                    self._following = self._following && self.options.onLocationOutsideMapBounds(self);
                 } else {
                     map.fitBounds(self._event.bounds);
                 }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -34,7 +34,6 @@ L.Control.Locate = L.Control.extend({
         },
         onLocationOutsideMapBounds: function(context) {
             alert(context.options.strings.outsideMapBoundsMsg);
-            return false;
         },
         setView: true, // automatically sets the map view to the user's location
         strings: {
@@ -143,14 +142,11 @@ L.Control.Locate = L.Control.extend({
         var visualizeLocation = function() {
             var radius = self._event.accuracy / 2;
             if (self._locateOnNextLocationFound) {
-                var jumpToLocation = true;
                 if (isOutsideMapBounds()) {
-                    jumpToLocation = self.options.onLocationOutsideMapBounds(self);
-                }
-                if (jumpToLocation) {
-                    map.fitBounds(self._event.bounds);
-                } else {
+                    self.options.onLocationOutsideMapBounds(self);
                     self._following = false;
+                } else{
+                    map.fitBounds(self._event.bounds);
                 }
                 self._locateOnNextLocationFound = false;
             }
@@ -218,6 +214,7 @@ L.Control.Locate = L.Control.extend({
 
             self._layer.clearLayers();
         };
+
 
         var onLocationError = function (err) {
             // ignore timeout error if the location is watched

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -143,10 +143,14 @@ L.Control.Locate = L.Control.extend({
         var visualizeLocation = function() {
             var radius = self._event.accuracy / 2;
             if (self._locateOnNextLocationFound) {
+                var jumpToLocation = true;
                 if (isOutsideMapBounds()) {
-                    self._following = self._following && self.options.onLocationOutsideMapBounds(self);
-                } else {
+                    jumpToLocation = self.options.onLocationOutsideMapBounds(self);
+                }
+                if (jumpToLocation) {
                     map.fitBounds(self._event.bounds);
+                } else {
+                    self._following = false;
                 }
                 self._locateOnNextLocationFound = false;
             }


### PR DESCRIPTION
When the map has defined boundaries (maxBounds), do not move
to the location if it is outside the boundaries.
Added "onLocationOutsideMapBounds" option to trigger a callback
and customize the behaviour. By default move is aborted and
message from newly defined "options.strings.outsideMapBoundsMsg"
is displayed. Fixes #25
