### PR TITLE
fixing blue image offset

### DIFF
--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -27,7 +27,7 @@
 }
 
 .leaflet-control-locate.active a {
-    background-position: -31px -2px;
+    background-position: -32px -2px;
 }
 
 .leaflet-control-locate.active.following a {


### PR DESCRIPTION
The blue circle was offset to the right by 1 pixel.

Before:
![screen shot 2013-07-03 at 12 32 31 pm](https://f.cloud.github.com/assets/370976/744523/3e58598a-e3fe-11e2-81e2-c67485acdf7e.png)

After:
![screen shot 2013-07-03 at 12 32 41 pm](https://f.cloud.github.com/assets/370976/744524/3e5902d6-e3fe-11e2-9b97-468d3466b01f.png)
