### PR TITLE
remove unnecessary CSS declarations

### DIFF
--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -16,12 +16,12 @@
 }
 
 .leaflet-control-locate.requesting a {
-    background-image: url(images/spinner.gif);
-    background-position: 50% 50%;
+	background-image: url(images/spinner.gif);
+	background-position: 50% 50%;
 }
 
 .leaflet-control-locate.active a {
-    background-position: -32px -2px;
+	background-position: -32px -2px;
 }
 
 .leaflet-control-locate.active.following a {

--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -1,11 +1,5 @@
 /* Compatible with Leaflet 0.6 */
 
-.leaflet-bar-part-single {
-	-webkit-border-radius: 4px 4px 4px 4px;
-	        border-radius: 4px 4px 4px 4px;
-	border-bottom: none;
-}
-
 .leaflet-touch .leaflet-bar-part-single {
 	-webkit-border-radius: 7px 7px 7px 7px;
 	        border-radius: 7px 7px 7px 7px;

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -49,7 +49,7 @@ L.Control.Locate = L.Control.extend({
 
     onAdd: function (map) {
         var className = 'leaflet-control-locate',
-            classNames = className + ' leaflet-control-zoom leaflet-bar leaflet-control',
+            classNames = className + ' leaflet-bar leaflet-control',
             container = L.DomUtil.create('div', classNames);
 
         var self = this;


### PR DESCRIPTION
Unless I'm mistaken, you don't need to class it with `leaflet-control-zoom`.

Also, all its corners will be rounded by the leaflet CSS, so no need to round them yourself.
