### PR TITLE
Add event firings to startFollowing and stopFollowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ L.control.locate({
 	position: 'topleft',  // set the location of the control
     drawCircle: true,  // controls whether a circle is drawn that shows the uncertainty about the location
     follow: false,  // follow the location if `watch` and `setView` are set to true in locateOptions
-    stopFollowingOnDrag: false, // stop following when the map is dragged if `follow` is set to true
+    stopFollowingOnDrag: false, // stop following when the map is dragged if `follow` is set to true (deprecated)
     circleStyle: {},  // change the style of the circle around the user's location
     markerStyle: {},
     followCircleStyle: {},  // set difference for the style of the circle around the user's location while following

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -9,7 +9,7 @@ L.Control.Locate = L.Control.extend({
         position: 'topleft',
         drawCircle: true,
         follow: false,  // follow with zoom and pan the user's location
-        stopFollowingOnDrag: false, // if follow is true, stop following when map is dragged
+        stopFollowingOnDrag: false, // if follow is true, stop following when map is dragged (deprecated)
         // range circle
         circleStyle: {
             color: '#136AEC',
@@ -140,6 +140,7 @@ L.Control.Locate = L.Control.extend({
         };
 
         var startFollowing = function() {
+            map.fire('startfollowing')
             self._following = true;
             if (self.options.stopFollowingOnDrag) {
                 map.on('dragstart', stopFollowing);
@@ -147,6 +148,7 @@ L.Control.Locate = L.Control.extend({
         };
 
         var stopFollowing = function() {
+            map.fire('stopfollowing');
             self._following = false;
             if (self.options.stopFollowingOnDrag) {
                 map.off('dragstart', stopFollowing);


### PR DESCRIPTION
Resolves #43.

This PR adds Leaflet map event firings to `startFollowing` and `stopFollowing`, thereby allowing developers to take action based on following status.

It also deprecates the `stopFollowingOnDrag` option in favor of binding a `stopFollowing` call to arbitrary events.
