### PR TITLE
Circle Marker Fixes

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -189,6 +189,9 @@ L.Control.Locate = L.Control.extend({
                         .addTo(self._layer);
                 } else {
                     self._circle.setLatLng(self._event.latlng).setRadius(radius);
+                    for (var styleOption in style) {
+                        self._circle.options[styleOption] = style[styleOption];
+                    }
                 }
             }
 
@@ -218,6 +221,9 @@ L.Control.Locate = L.Control.extend({
                 self._circleMarker.setLatLng(self._event.latlng)
                     .bindPopup(L.Util.template(t, {distance: distance, unit: unit}))
                     ._popup.setLatLng(self._event.latlng);
+                for (var styleOption in m) {
+                    self._circleMarker.options[styleOption] = m[styleOption];
+                }
             }
 
             if (!self._container)


### PR DESCRIPTION
This branch resolves the inability of circle markers to change style based on the `_following` status. It also moves the `L.circle.setLatLng` calls to the ends of relevant method chains (as this method does not return the object like the other methods do).
