### PR TITLE
Style tweaks for Leaflet 0.7

### DIFF
--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -31,5 +31,5 @@
 .leaflet-touch .leaflet-control-locate {
 	box-shadow: none;
 	border: 2px solid rgba(0,0,0,0.2);
-    	background-clip: padding-box;
+	background-clip: padding-box;
 }

--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -1,4 +1,4 @@
-/* Compatible with Leaflet 0.6 */
+/* Compatible with Leaflet 0.7 */
 
 .leaflet-touch .leaflet-bar-part-single {
 	-webkit-border-radius: 7px 7px 7px 7px;
@@ -30,5 +30,6 @@
 
 .leaflet-touch .leaflet-control-locate {
 	box-shadow: none;
-	border: 4px solid rgba(0,0,0,0.3);
+	border: 2px solid rgba(0,0,0,0.2);
+    	background-clip: padding-box;
 }


### PR DESCRIPTION
This update brings the locate control in line with 0.7.1, which introduced a more subtle border around mobile controls. See https://github.com/Leaflet/Leaflet/issues/1868 and https://github.com/Leaflet/Leaflet/commit/ea6095f259a1d3ba950526e446d4f8d11334abae.
