### PR TITLE
New remainActive option and new onClick hook.

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -38,6 +38,9 @@ L.Control.Locate = L.Control.extend({
         iconLoading: 'icon-spinner animate-spin',
         circlePadding: [0, 0],
         metric: true,
+        onClick: function(control){
+            // this event is called when the user clicks on the locate control
+        },
         onLocationError: function(err) {
             // this event is called in case of any location error
             // that is not a time out error.
@@ -49,6 +52,9 @@ L.Control.Locate = L.Control.extend({
             alert(context.options.strings.outsideMapBoundsMsg);
         },
         setView: true, // automatically sets the map view to the user's location
+        // locate control remains active on click even if the user's
+        // location is in view.
+        remainActive: true,
         // keep the current map zoom level when displaying the user's location. (if 'false', use maxZoom)
         keepCurrentZoomLevel: false,
         strings: {
@@ -94,12 +100,24 @@ L.Control.Locate = L.Control.extend({
             .on(link, 'click', L.DomEvent.stopPropagation)
             .on(link, 'click', L.DomEvent.preventDefault)
             .on(link, 'click', function() {
-                if (self._active && (self._event === undefined || map.getBounds().contains(self._event.latlng) || !self.options.setView ||
-                    isOutsideMapBounds())) {
+                if (self._active
+                    && (self._event === undefined
+                        || isOutsideMapBounds()
+                        || (!self.options.remainActive
+                            && (map.getBounds().contains(self._event.latlng)
+                                || !self.options.setView
+                            )
+                        )
+                    )
+                ) {
                     stopLocate();
                 } else {
                     locate();
                 }
+
+            })
+            .on(link, 'click', function(){
+                self.options.onClick(self);
             })
             .on(link, 'dblclick', L.DomEvent.stopPropagation);
 


### PR DESCRIPTION
I've added two new options that might be useful to others as well:

| Option | Type | Description |
| :-- | :-- | :-- |
| `remainActive` | _boolean_ | Should the locate control remain active on click even if the user's location is in view |
| `onClick` | _function_ | Event hook, called when the user clicks on the locate control |

My use case that I needed this functionality for is the following:

I want users to be able to locate themselves on the map,and also be able to adjust the position of the marker (but not the circle) after they have been located. If the locate control button is clicked again, it moves the marker back to its' original position (hence the `onClick` hook) and does not deactivate the control even if it's in view (hence the `remainActive` option).

This use case is illustrated in this jsfiddle, where I linked in my fork of the leaflet-locatecontrol:
http://jsfiddle.net/LhGEW/

Cheers
