### PR TITLE
Added new option for always on location, regardless of clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ L.control.locate({
     setView: true, // automatically sets the map view to the user's location, enabled if `follow` is true
     keepCurrentZoomLevel: false, // keep the current map zoom level when displaying the user's location. (if `false`, use maxZoom)
     stopFollowingOnDrag: false, // stop following when the map is dragged if `follow` is true (deprecated, see below)
+    remainActive: false, // If true location is always active. Clicking control will just pan to location
     markerClass: L.circleMarker, // L.circleMarker or L.marker
     circleStyle: {},  // change the style of the circle around the user's location
     markerStyle: {},

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -10,7 +10,7 @@ L.Control.Locate = L.Control.extend({
         drawCircle: true,
         follow: false,  // follow with zoom and pan the user's location
         stopFollowingOnDrag: false, // if follow is true, stop following when map is dragged (deprecated)
-        alwaysOn: false,
+        remainActive: false, // If true location is always active. Clicking control will just pan to location
         markerClass: L.circleMarker, // L.circleMarker or L.marker
         // range circle
         circleStyle: {
@@ -96,7 +96,7 @@ L.Control.Locate = L.Control.extend({
             .on(link, 'click', L.DomEvent.stopPropagation)
             .on(link, 'click', L.DomEvent.preventDefault)
             .on(link, 'click', function() {
-                if (!self.options.alwaysOn && (self._active && (self._event === undefined || map.getBounds().contains(self._event.latlng) || !self.options.setView ||
+                if (!self.options.remainActive && (self._active && (self._event === undefined || map.getBounds().contains(self._event.latlng) || !self.options.setView ||
                     isOutsideMapBounds()))) {
                     stopLocate();
                 } else {

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -10,6 +10,7 @@ L.Control.Locate = L.Control.extend({
         drawCircle: true,
         follow: false,  // follow with zoom and pan the user's location
         stopFollowingOnDrag: false, // if follow is true, stop following when map is dragged (deprecated)
+        alwaysOn: false,
         markerClass: L.circleMarker, // L.circleMarker or L.marker
         // range circle
         circleStyle: {
@@ -95,8 +96,8 @@ L.Control.Locate = L.Control.extend({
             .on(link, 'click', L.DomEvent.stopPropagation)
             .on(link, 'click', L.DomEvent.preventDefault)
             .on(link, 'click', function() {
-                if (self._active && (self._event === undefined || map.getBounds().contains(self._event.latlng) || !self.options.setView ||
-                    isOutsideMapBounds())) {
+                if (!self.options.alwaysOn && (self._active && (self._event === undefined || map.getBounds().contains(self._event.latlng) || !self.options.setView ||
+                    isOutsideMapBounds()))) {
                     stopLocate();
                 } else {
                     locate();


### PR DESCRIPTION
Hello, I find the 'triple click' behaviour of the locate button a bit unnatural. I would prefer to:
1. Click once to follow/set the view and watch
2. Stop following on drag, but keep watching. 
3. Clicking again just relocates and follows (rather than switches off geolocation). 

For this I've added an `alwaysOn` option and negated the whole stopLocate behaviour on click, if it's true. 
