### PR TITLE
Keep zoom level if drawCircle: false and keepCurrentZoomLevel: true

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -165,11 +165,18 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
                 if (this._isOutsideMapBounds()) {
                     this.options.onLocationOutsideMapBounds(this);
                 } else {
-                    map.fitBounds(this._event.bounds, {
-                        padding: this.options.circlePadding,
-                        maxZoom: this.options.keepCurrentZoomLevel ?
+                    // If accuracy info isn't desired, keep the current zoom level
+                    if(this.options.keepCurrentZoomLevel && !this.options.drawCircle){
+                        map.panTo([this._event.latitude, this._event.longitude], {
+                            maxZoom: map.getZoom()
+                        });
+                    } else {
+                        map.fitBounds(this._event.bounds, {
+                            padding: this.options.circlePadding,
+                            maxZoom: this.options.keepCurrentZoomLevel ?
                             map.getZoom() : this.options.locateOptions.maxZoom
-                    });
+                        });
+                    }
                 }
                 this._locateOnNextLocationFound = false;
             }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -167,9 +167,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
                 } else {
                     // If accuracy info isn't desired, keep the current zoom level
                     if(this.options.keepCurrentZoomLevel && !this.options.drawCircle){
-                        map.panTo([this._event.latitude, this._event.longitude], {
-                            maxZoom: map.getZoom()
-                        });
+                        map.panTo([this._event.latitude, this._event.longitude]);
                     } else {
                         map.fitBounds(this._event.bounds, {
                             padding: this.options.circlePadding,


### PR DESCRIPTION
This checks if `drawCircle: false` and `keepCurrentZoomLevel: true`, and then does a `panTo` on the map instead of `fitBounds`. This covers the very specific edge case of not wanting any accuracy information, while having terrible GPS accuracy.

In short: if `drawCircle: false` and `keepCurrentZoomLevel: true`, we can assume that accuracy info (the circle overlay) isn't wanted or even visible, so we shouldn't be zooming out to accommodate it (regardless of the actual accuracy).

This zooming is totally disorienting on very low accuracy geolocations, which will zoom out massively to fit the huge (in my case, 60km across) _but also invisible_ accuracy circle, going to something as far out as zoom level 9 for no apparent reason. 

See #102 for further info. 
