### PR TITLE
Advanced configuration. Display control together with zoom.

### DIFF
--- a/dist/L.Control.Locate.css
+++ b/dist/L.Control.Locate.css
@@ -1,25 +1,13 @@
 /*! Version: 0.43.0
 Date: 2015-05-27 */
 
-/* Compatible with Leaflet 0.7 */
-.leaflet-touch .leaflet-bar-part-single {
-  -webkit-border-radius: 7px 7px 7px 7px;
-  border-radius: 7px 7px 7px 7px;
-  border-bottom: none;
-}
-.leaflet-touch .leaflet-control-locate {
-  box-shadow: none;
-  border: 2px solid rgba(0, 0, 0, 0.2);
-  background-clip: padding-box;
-}
-
-.leaflet-control-locate a {
+a.leaflet-control-locate {
   font-size: 1.4em;
   color: #444;
 }
-.leaflet-control-locate.active a {
+a.leaflet-control-locate.active {
   color: #2074B6;
 }
-.leaflet-control-locate.active.following a {
+a.leaflet-control-locate.active.following {
   color: #FC8428;
 }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -89,7 +89,8 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             locateOptions: {
                 maxZoom: Infinity,
                 watch: true  // if you overwrite this, visualization cannot be updated
-            }
+            },
+            displayWithZoomControl: false
         },
 
         initialize: function (options) {
@@ -267,8 +268,14 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
         },
 
         onAdd: function (map) {
-            var container = L.DomUtil.create('div',
-                'leaflet-control-locate leaflet-bar leaflet-control');
+            var container;
+
+            // check if zoom control was accepted before and locate control would be displayed with it
+            if (map.zoomControl && this.options.displayWithZoomControl) {
+              container = map.zoomControl._container;
+            } else {
+              container = L.DomUtil.create('div', 'leaflet-bar leaflet-control');
+            }
 
             this._layer = new L.LayerGroup();
             this._layer.addTo(map);
@@ -282,7 +289,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             L.extend(tmp, this.options.circleStyle, this.options.followCircleStyle);
             this.options.followCircleStyle = tmp;
 
-            this._link = L.DomUtil.create('a', 'leaflet-bar-part leaflet-bar-part-single', container);
+            this._link = L.DomUtil.create('a', 'leaflet-control-locate', container);
             this._link.href = '#';
             this._link.title = this.options.strings.title;
             this._icon = L.DomUtil.create('span', this.options.icon, this._link);


### PR DESCRIPTION
Added ability to display `locate` control together with `zoom` control.
1. added option to switch the situation. Used `false` by default.
2. check if zoom control displays on a map.
3. corrected css-styles. Leaflet rules.

See attached pic as the working result.
![control-locate](https://cloud.githubusercontent.com/assets/5160609/8021911/d6ff2316-0cbb-11e5-9ac4-dfe0d7e4ccbb.png)
