### PR TITLE
send signal when starting and stopping locator

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -330,6 +330,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             } else {
                 this.drawMarker(this._map);
             }
+            this._map.fire('startlocator', this);
         },
 
         /**
@@ -345,6 +346,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             this._resetVariables();
 
             this.removeMarker();
+            this._map.fire('stoplocator', this);
         },
 
         /**


### PR DESCRIPTION
I would suggest sending a signal when starting and stopping the locator. This provides a clean way to know when the locator is active or not.

(I use it for updating my URL so that if users bookmark my app when the locator is active it will be reflected in the URL)

The same effect can of course be achieved by extending (overriding) the start and stop methods without changing anything in the leaflet-locatecontrol code itself.

Best regards,
Jesper
