### PR TITLE
Fixing reference to font-awesome library

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,6 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "leaflet": "~0.7.3",
-    "fontawesome": "~4.3.0"
+    "font-awesome": "~4.3.0"
   }
 }


### PR DESCRIPTION
Bower could not resolve dependencies on my machine when using "fontawesome". The solution is renaming it to "font-awesome".
