### PR TITLE
Add "tagNameForIconElement" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ L.control.locate({
     followMarkerStyle: {},
     icon: 'fa fa-map-marker',  // class for icon, fa-location-arrow or fa-map-marker
     iconLoading: 'fa fa-spinner fa-spin',  // class for loading icon
-    tagNameForIconElement: 'span',  // set the icon element tag
+    iconElementTag: 'span',  // tag for the icon element, span or i
     circlePadding: [0, 0], // padding around accuracy circle, value is passed to setBounds
     metric: true,  // use metric or imperial units
     onLocationError: function(err) {alert(err.message)},  // define an error callback function

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ L.control.locate({
     followMarkerStyle: {},
     icon: 'fa fa-map-marker',  // class for icon, fa-location-arrow or fa-map-marker
     iconLoading: 'fa fa-spinner fa-spin',  // class for loading icon
+    tagNameForIconElement: 'span',  // set the icon element tag
     circlePadding: [0, 0], // padding around accuracy circle, value is passed to setBounds
     metric: true,  // use metric or imperial units
     onLocationError: function(err) {alert(err.message)},  // define an error callback function

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -64,7 +64,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             },
             icon: 'fa fa-map-marker',  // fa-location-arrow or fa-map-marker
             iconLoading: 'fa fa-spinner fa-spin',
-            tagNameForIconElement: 'span', // i
+            iconElementTag: 'span', // span or i
             circlePadding: [0, 0],
             metric: true,
             onLocationError: function(err) {
@@ -287,7 +287,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             this._link = L.DomUtil.create('a', 'leaflet-bar-part leaflet-bar-part-single', container);
             this._link.href = '#';
             this._link.title = this.options.strings.title;
-            this._icon = L.DomUtil.create(this.options.tagNameForIconElement, this.options.icon, this._link);
+            this._icon = L.DomUtil.create(this.options.iconElementTag, this.options.icon, this._link);
 
             L.DomEvent
                 .on(this._link, 'click', L.DomEvent.stopPropagation)

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -64,6 +64,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             },
             icon: 'fa fa-map-marker',  // fa-location-arrow or fa-map-marker
             iconLoading: 'fa fa-spinner fa-spin',
+            tagNameForIconElement: 'span', // i
             circlePadding: [0, 0],
             metric: true,
             onLocationError: function(err) {
@@ -286,7 +287,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             this._link = L.DomUtil.create('a', 'leaflet-bar-part leaflet-bar-part-single', container);
             this._link.href = '#';
             this._link.title = this.options.strings.title;
-            this._icon = L.DomUtil.create('span', this.options.icon, this._link);
+            this._icon = L.DomUtil.create(this.options.tagNameForIconElement, this.options.icon, this._link);
 
             L.DomEvent
                 .on(this._link, 'click', L.DomEvent.stopPropagation)


### PR DESCRIPTION
Make the tag name for the icon element configurable so it can be used with icon sets which don't uses the "span" element.

Working example for [Semantic UI](https://github.com/Semantic-Org/Semantic-UI):

``` js
L.control.locate({
  icon: 'fitted marker icon',
  iconLoading: 'fitted spinner loading icon',
  tagNameForIconElement: 'i'
}).addTo(map);
```
