### PR TITLE
Change setView to respect user panning.

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -172,19 +172,16 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             }
 
             var radius = this._event.accuracy;
-            if (this._locateOnNextLocationFound) {
+            if (this._locateOnNextLocationFound &&
+              // If user hasn't panned.
+              !(this.options.setView === 'untilPan' && this._userPanned)) {
+
                 if (this._isOutsideMapBounds()) {
                     this.options.onLocationOutsideMapBounds(this);
                 } else {
                     // If accuracy info isn't desired, keep the current zoom level
                     if(this.options.keepCurrentZoomLevel) {
-                      // If user hasn't panned.
-                      if (this.options.setView === 'always' || !this._userPanned) {
-                        console.log('Panning to ' + [this._event.latitude, this._event.longitude]);
                         map.panTo([this._event.latitude, this._event.longitude]);
-                      } else {
-                        console.log('Not panning, $this._userPanned == true. Moving marker to ' + [this._event.latitude, this._event.longitude]);
-                      }
                     } else {
                         map.fitBounds(this._event.bounds, {
                             padding: this.options.circlePadding,


### PR DESCRIPTION
PR for #149.

Tested on desktop and mobile (iOS).

I considered adding the `_userPanned` guard to the code that sets `_locateOnNextLocationFound` to `true`, but decided not to because I wasn't clear on the flow / logic.
