### PR TITLE
Check for this._event before calling _drawMarker()

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -428,7 +428,9 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
         _onDrag: function() {
             this._userPanned = true;
             this._updateContainerStyle();
-            this._drawMarker();
+            if (this._event) {
+                this._drawMarker();
+            }
         },
 
         /**


### PR DESCRIPTION
Alternate solution for #161.

In `_onDrag()`, check for this._event before calling `_drawMarker()`.

Tested in Chrome and Safari.
