### PR TITLE
Accessibility fix

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -174,7 +174,6 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             this._prevBounds = null;
 
             this._link = L.DomUtil.create('a', 'leaflet-bar-part leaflet-bar-part-single', container);
-            this._link.href = '#';
             this._link.title = this.options.strings.title;
             this._icon = L.DomUtil.create(this.options.iconElementTag, this.options.icon, this._link);
 


### PR DESCRIPTION
Remove the location button's href link (`<a href="#">`) to remove the empty link accessibility issue. See [WebAIM's website](http://webaim.org/techniques/hypertext/#keyboard) for more information about web links and accessibility.

# Before
<img width="45" alt="screen shot 2017-01-21 at 16 13 40" src="https://cloud.githubusercontent.com/assets/5023024/22178145/d895a084-dff4-11e6-8095-0b3d484b5ee6.png">  

<img width="214" alt="screen shot 2017-01-21 at 16 15 09" src="https://cloud.githubusercontent.com/assets/5023024/22178148/dc0ac69a-dff4-11e6-82a8-43e2fdc7bc2c.png">  
 

# After  
<img width="53" alt="screen shot 2017-01-21 at 16 14 05" src="https://cloud.githubusercontent.com/assets/5023024/22178150/ded2f316-dff4-11e6-8a2a-0c90f74f2c3b.png">  