### PR TITLE
Support functions for `strings.popup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `onLocationOutsideMapBounds` | `function`  | Use metric units. | see code |
 | `showPopup` | `boolean`  | Display a pop-up when the user click on the inner marker. | `true` |
 | `strings` | `object`  | Strings used in the control. Options are `title`, `metersUnit`, `feetUnit`, `popup`, and `outsideMapBoundsMsg` | see code |
+| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}` and `{unit}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit}` and expected to return a string. | see code |
 | `locateOptions` | [`Locate options`](http://leafletjs.com/reference.html#map-locate-options)  | The default options passed to leaflets locate method. | see code |
 
 For example, to customize the position and the title, you could write

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -625,14 +625,23 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             this._drawCompass();
 
             var t = this.options.strings.popup;
+            function getPopupText() {
+                if (typeof t === 'string') {
+                    return L.Util.template(t, {distance: distance, unit: unit});
+                } else if (typeof t === 'function') {
+                    return t({distance: distance, unit: unit});
+                } else {
+                    return t;
+                }
+            }
             if (this.options.showPopup && t && this._marker) {
                 this._marker
-                    .bindPopup(L.Util.template(t, {distance: distance, unit: unit}))
+                    .bindPopup(getPopupText())
                     ._popup.setLatLng(latlng);
             }
             if (this.options.showPopup && t && this._compass) {
                 this._compass
-                    .bindPopup(L.Util.template(t, {distance: distance, unit: unit}))
+                    .bindPopup(getPopupText())
                     ._popup.setLatLng(latlng);
             }
         },


### PR DESCRIPTION
This allows to use an external i18n system with its argument and plural handling.

As a not very serious example for testing, you may want to try:

```javascript
{
  strings: {
    popup: args => `You are witih half of ${args.distance * 2} ${args.unit}`
  }
}
```