### PR TITLE
Option 'initialZoomLevel': zoom to specified zoom level after click

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `setView` | `boolean`  or `string`  | Set the map view (zoom and pan) to the user's location as it updates. Options are `false`, `'once'`, `'always'`, `'untilPan'`, or `'untilPanOrZoom'` | `'untilPanOrZoom'` |
 | `flyTo` | `boolean` | Smooth pan and zoom to the location of the marker. Only works in Leaflet 1.0+. | `false` |
 | `keepCurrentZoomLevel` | `boolean`  | Only pan when setting the view. | `false` |
+| `initialZoomLevel` | `false` or `integer` | After activating the plugin by clicking on the icon, zoom to the selected zoom level, even when keepCurrentZoomLevel is true. Set to `false` to disable this feature. | `false` |
 | `clickBehavior` | `object`  | What to do when the user clicks on the control. Has three options `inView`, `inViewNotFollowing` and `outOfView`. Possible values are `stop` and `setView`, or the name of a behaviour to inherit from. | `{inView: 'stop', outOfView: 'setView', inViewNotFollowing: 'inView'}` |
 | `returnToPrevBounds` | `boolean`  | If set, save the map bounds just before centering to the user's location. When control is disabled, set the view back to the bounds that were saved. | `false` |
 | `cacheLocation` | `boolean` | Keep a cache of the location after the user deactivates the control. If set to false, the user has to wait until the locate API returns a new location before they see where they are again. | `true` |

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -168,6 +168,8 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             setView: 'untilPanOrZoom',
             /** Keep the current map zoom level when setting the view and only pan. */
             keepCurrentZoomLevel: false,
+	    /** After activating the plugin by clicking on the icon, zoom to the selected zoom level, even when keepCurrentZoomLevel is true. Set to 'false' to disable this feature. */
+	    initialZoomLevel: false,
             /**
              * This callback can be used to override the viewport tracking
              * This function should return a LatLngBounds object.
@@ -525,6 +527,10 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
                 this._event = undefined;  // clear the current location so we can get back into the bounds
                 this.options.onLocationOutsideMapBounds(this);
             } else {
+		if (this._justClicked && this.options.initialZoomLevel !== false) {
+                    var f = this.options.flyTo ? this._map.flyTo : this._map.setView;
+                    f.bind(this._map)([this._event.latitude, this._event.longitude], this.options.initialZoomLevel);
+		} else
                 if (this.options.keepCurrentZoomLevel) {
                     var f = this.options.flyTo ? this._map.flyTo : this._map.panTo;
                     f.bind(this._map)([this._event.latitude, this._event.longitude]);


### PR DESCRIPTION
This pull requests adds an option 'initialZoomLevel', which will zoom to the specified zoom level to zoom to after clicking on the icon (even when keepCurrentZoomLevel is `true`).

In my app I want to zoom to a specified zoom level when acquiring a position, but when the user changes the zoom while the plugin is active, it should not change zoom any more.