### PR TITLE
Set this._map in onAdd for controls outside the map

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -335,6 +335,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
         onAdd: function (map) {
             var container = L.DomUtil.create('div',
                 'leaflet-control-locate leaflet-bar leaflet-control');
+            this._container = container;
             this._map = map;
             this._layer = this.options.layer || new L.LayerGroup();
             this._layer.addTo(map);

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -335,7 +335,7 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
         onAdd: function (map) {
             var container = L.DomUtil.create('div',
                 'leaflet-control-locate leaflet-bar leaflet-control');
-
+            this._map = map;
             this._layer = this.options.layer || new L.LayerGroup();
             this._layer.addTo(map);
             this._event = undefined;


### PR DESCRIPTION
I'm trying to use this plugin outside of the map so I don't call addTo(map).

When I use onAdd() this._map is not set, so this PR sets it.

Example from leaflet-control-geocoder: https://github.com/perliedman/leaflet-control-geocoder/blob/b8ebba11dd04a06576c1a67f0d302bc9e7ec7b44/src/control.js#L39