### PR TITLE
Corrected README event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can keep the plugin active but stop following using `lc.stopFollowing()`.
 
 ### Events
 
-You can leverage the native Leaflet events `onlocationfound` and `onlocationerror` to handle when geolocation is successful or produces an error. You can find out more about these events in the [Leaflet documentation](http://leafletjs.com/examples/mobile.html#geolocation).
+You can leverage the native Leaflet events `locationfound` and `locationerror` to handle when geolocation is successful or produces an error. You can find out more about these events in the [Leaflet documentation](http://leafletjs.com/examples/mobile.html#geolocation).
 
 Additionally, the locate control fires `locateactivate` and `locatedeactivate` events on the map object when it is activated and deactivated, respectively.
 


### PR DESCRIPTION
Corrected README event names for the Leaflet [native events](https://leafletjs.com/reference.html#map-locationerror).