### PR TITLE
Fix icon position (mapbox)

### DIFF
--- a/src/L.Control.Locate.mapbox.scss
+++ b/src/L.Control.Locate.mapbox.scss
@@ -2,13 +2,7 @@
 
 /* Mapbox specific adjustments */
 
-.leaflet-control-locate {
-  a {
-    padding: 3px 0 0 8px;
-  }
-  &.requesting {
-    a {
-      padding: 3px 0 0 4px;
-    }
-  }
+.leaflet-control-locate a .leaflet-control-locate-location-arrow,
+.leaflet-control-locate a .leaflet-control-locate-spinner {
+  margin: 5px;
 }


### PR DESCRIPTION
This fixes the icon position. This issues only occured when you use the mapbox css like in the mapbox demo: https://domoritz.github.io/leaflet-locatecontrol/demo_mapbox/

| before | after |
|---|---|
| ![before](https://user-images.githubusercontent.com/35647502/198819760-20ef0a76-c798-496a-a5d8-0d4b77e7ffbe.png) | ![after](https://user-images.githubusercontent.com/35647502/198819759-9ab3bdc7-9b87-4f92-8769-c1b2b05fa5a2.png) |
| ![spinner_before](https://user-images.githubusercontent.com/35647502/198820207-5e707981-f766-4b5a-b022-7885abcc8395.png) | ![spinner_after](https://user-images.githubusercontent.com/35647502/198820209-3ab69ed8-a0bc-4329-ac22-41a9d96b2a3d.png) |


