### PR TITLE
Export dist module as default instead of src.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.79.0",
   "homepage": "https://github.com/domoritz/leaflet-locatecontrol",
   "description": "A useful control to geolocate the user with many options. Used by osm.org and mapbox among many others.",
-  "main": "src/L.Control.Locate.js",
+  "main": "dist/L.Control.Locate.min.js",
   "author": "Dominik Moritz <domoritz@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This reduces the bundle size by 60%, 30.85kb to 12.37kb.