### PR TITLE
Fix a little annoyance with hot module reloading

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -699,7 +699,10 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
      */
     _unload() {
       this.stop();
-      this._map.off("unload", this._unload, this);
+      // May become undefined during HMR
+      if (this._map) {
+        this._map.off("unload", this._unload, this);
+      }
     },
 
     /**


### PR DESCRIPTION
Hey,

Thank you for this package! I'm using it with react-leaflet for a remix-run app.

I consistently have an issue when editing code, and hot module reload happens. It seems that somehow the map instance gets destroyed before the _unload() event handler runs, hence this patch.

Let me know if you think there's a better way to do it.