### PR TITLE
refactor: replace deprecated Leaflet DOM helpers and factory functions for Leaflet 2 compatibility

### DIFF
--- a/demo/esm/leaflet2.html
+++ b/demo/esm/leaflet2.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Demo Leaflet.Locate - Leaflet 2</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../../favicon.svg" />
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@2.0.0-alpha.1/dist/leaflet.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "leaflet": "https://cdn.jsdelivr.net/npm/leaflet@2.0.0-alpha.1/dist/leaflet-src.js"
+        }
+      }
+    </script>
+    <link rel="stylesheet" href="../../dist/L.Control.Locate.min.css" />
+    <link rel="stylesheet" href="../style.css" />
+    <script type="module" src="script.js"></script>
+  </head>
+  <body>
+    <button id="dark-mode-toggle" title="Demo: Toggle Dark Mode">🌓</button>
+    <div id="map" style="width: 100%; height: 100%"></div>
+    <div id="forkmeongithub"><a href="https://github.com/domoritz/leaflet-locatecontrol" target="_blank">Fork me on GitHub</a></div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -264,6 +264,9 @@
           <a href="demo/esm/">Leaflet ESM</a>
         </li>
         <li>
+          <a href="demo/esm/leaflet2.html">Leaflet 2</a>
+        </li>
+        <li>
           <a href="demo/mapbox/">Mapbox UMD</a>
         </li>
       </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "prettier": "^3.8.1",
         "rollup": "^4.57.1",
         "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0 || >=2.0.0-alpha.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "prettier": "^3.8.1",
     "rollup": "^4.57.1",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "leaflet": "^1.9.0 || >=2.0.0-alpha.1"
   }
 }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -5,7 +5,7 @@ This file is part of the leaflet locate control. It is licensed under the MIT li
 You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
 */
 
-import { Control, Marker, setOptions, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
+import { Control, Marker, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
 
 const METERS_TO_FEET = 3.2808399;
 
@@ -71,7 +71,7 @@ function cloneOptions(options) {
  */
 const LocationMarker = Marker.extend({
   initialize(latlng, options) {
-    setOptions(this, options);
+    LeafletUtil.setOptions(this, options);
     this._latlng = latlng;
     this.createIcon();
   },
@@ -126,14 +126,14 @@ const LocationMarker = Marker.extend({
   },
 
   setStyle(style) {
-    setOptions(this, style);
+    LeafletUtil.setOptions(this, style);
     this.createIcon();
   }
 });
 
 const CompassMarker = LocationMarker.extend({
   initialize(latlng, heading, options) {
-    setOptions(this, options);
+    LeafletUtil.setOptions(this, options);
     this._latlng = latlng;
     this._heading = heading;
     this.createIcon();
@@ -398,9 +398,9 @@ const LocateControl = Control.extend({
     }
 
     // Follow styles inherit from base styles
-    Object.assign(this.options.followMarkerStyle, this.options.markerStyle, this.options.followMarkerStyle);
-    Object.assign(this.options.followCircleStyle, this.options.circleStyle, this.options.followCircleStyle);
-    Object.assign(this.options.followCompassStyle, this.options.compassStyle, this.options.followCompassStyle);
+    this.options.followMarkerStyle = { ...this.options.markerStyle, ...this.options.followMarkerStyle };
+    this.options.followCircleStyle = { ...this.options.circleStyle, ...this.options.followCircleStyle };
+    this.options.followCompassStyle = { ...this.options.compassStyle, ...this.options.followCompassStyle };
   },
 
   /**
@@ -420,16 +420,12 @@ const LocateControl = Control.extend({
     this._link = linkAndIcon.link;
     this._icon = linkAndIcon.icon;
 
-    DomEvent.on(
-      this._link,
-      "click",
-      function (ev) {
-        DomEvent.stopPropagation(ev);
-        DomEvent.preventDefault(ev);
-        this._onClick();
-      },
-      this
-    ).on(this._link, "dblclick", DomEvent.stopPropagation);
+    this._link.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+      this._onClick();
+    });
+    this._link.addEventListener("dblclick", (ev) => ev.stopPropagation());
 
     this._resetVariables();
 
@@ -731,7 +727,7 @@ const LocateControl = Control.extend({
       if (this._circle) {
         this._circle.setLatLng(latlng).setRadius(accuracy).setStyle(style);
       } else {
-        const options = Object.assign({}, style, { radius: accuracy });
+        const options = { ...style, radius: accuracy };
         this._circle = new Circle(latlng, options).addTo(this._layer);
       }
     }


### PR DESCRIPTION
Leaflet v2-alpha was released. A lot of legacy browser support stuff has been removed, and ESM builds are now the default. This PR changes all references to these deprecated/removed classes so leaflet-locatecontrol can be compatible with both v1 and v2 at the same time.