### PR TITLE
Fix rotation of compass arrow on Safari and Firefox

### DIFF
--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -88,11 +88,17 @@ const CompassMarker = LocationMarker.extend({
     setOptions(this, options);
     this._latlng = latlng;
     this._heading = heading;
+    this._arrowClass = "leaflet-control-locate-heading-arrow";
+    this._cssRule = this._getSvgCSSRule();
     this.createIcon();
   },
 
   setHeading(heading) {
     this._heading = heading;
+
+    if (this._cssRule) {
+      this._cssRule.style.setProperty("transform", `rotate(${this._heading}deg)`);
+    }
   },
 
   /**
@@ -104,7 +110,7 @@ const CompassMarker = LocationMarker.extend({
     const h = (r + options.depth + options.weight) * 2;
     const path = `M0,0 l${options.width / 2},${options.depth} l-${w},0 z`;
     const svg =
-      `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" version="1.1" viewBox="-${w / 2} 0 ${w} ${h}" transform="rotate(${this._heading})">` +
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" version="1.1" viewBox="-${w / 2} 0 ${w} ${h}" class="${this._arrowClass}">` +
       `<path d="${path}" ${style} /></svg>`;
     return {
       className: "leaflet-control-locate-heading",
@@ -112,6 +118,24 @@ const CompassMarker = LocationMarker.extend({
       w,
       h
     };
+  },
+
+  // Finds the CSS rule for the compass arrow so we can update its rotation without setting inline styles
+  _getSvgCSSRule() {
+    const selector = "." + this._arrowClass;
+
+    for (const sheet of document.styleSheets) {
+      // Ignore stylesheets from different origins
+      if (sheet.href && new URL(sheet.href).origin !== location.origin) {
+        continue;
+      }
+
+      for (const rule of sheet.cssRules) {
+        if (rule.selectorText === selector) {
+          return rule;
+        }
+      }
+    }
   }
 });
 

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -88,17 +88,11 @@ const CompassMarker = LocationMarker.extend({
     setOptions(this, options);
     this._latlng = latlng;
     this._heading = heading;
-    this._arrowClass = "leaflet-control-locate-heading-arrow";
-    this._cssRule = this._getSvgCSSRule();
     this.createIcon();
   },
 
   setHeading(heading) {
     this._heading = heading;
-
-    if (this._cssRule) {
-      this._cssRule.style.setProperty("transform", `rotate(${this._heading}deg)`);
-    }
   },
 
   /**
@@ -106,36 +100,45 @@ const CompassMarker = LocationMarker.extend({
    */
   _getIconSVG(options, style) {
     const r = options.radius;
-    const w = options.width + options.weight;
-    const h = (r + options.depth + options.weight) * 2;
-    const path = `M0,0 l${options.width / 2},${options.depth} l-${w},0 z`;
+    const s = r + options.weight + options.depth;
+    const s2 = s * 2;
+
+    const path = this._arrowPoints(r, options.width, options.depth, this._heading);
+
     const svg =
-      `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" version="1.1" viewBox="-${w / 2} 0 ${w} ${h}" class="${this._arrowClass}">` +
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${s2}" height="${s2}" version="1.1" viewBox="-${s} -${s} ${s2} ${s2}">` +
       `<path d="${path}" ${style} /></svg>`;
     return {
       className: "leaflet-control-locate-heading",
       svg,
-      w,
-      h
+      w: s2,
+      h: s2
     };
   },
 
-  // Finds the CSS rule for the compass arrow so we can update its rotation without setting inline styles
-  _getSvgCSSRule() {
-    const selector = "." + this._arrowClass;
+  _arrowPoints(radius, width, depth, heading) {
+    const φ = ((heading - 90) * Math.PI) / 180;
+    const ux = Math.cos(φ);
+    const uy = Math.sin(φ);
+    const vx = -Math.sin(φ);
+    const vy = Math.cos(φ);
+    const h = width / 2;
 
-    for (const sheet of document.styleSheets) {
-      // Ignore stylesheets from different origins
-      if (sheet.href && new URL(sheet.href).origin !== location.origin) {
-        continue;
-      }
+    // Base center on circle
+    const Cx = radius * ux;
+    const Cy = radius * uy;
 
-      for (const rule of sheet.cssRules) {
-        if (rule.selectorText === selector) {
-          return rule;
-        }
-      }
-    }
+    // Base corners
+    const B1x = Cx + h * vx;
+    const B1y = Cy + h * vy;
+    const B2x = Cx - h * vx;
+    const B2y = Cy - h * vy;
+
+    // Tip outward
+    const Tx = Cx + depth * ux;
+    const Ty = Cy + depth * uy;
+
+    return `M ${B1x},${B1y} L ${B2x},${B2y} L ${Tx},${Ty} Z`;
   }
 });
 

--- a/src/L.Control.Locate.scss
+++ b/src/L.Control.Locate.scss
@@ -54,6 +54,10 @@
   animation: leaflet-control-locate-throb 4s ease infinite;
 }
 
+.leaflet-control-locate-heading-arrow {
+  transform: rotate(0deg);
+}
+
 @keyframes leaflet-control-locate-throb {
   0% {
     stroke-width: 1;

--- a/src/L.Control.Locate.scss
+++ b/src/L.Control.Locate.scss
@@ -54,10 +54,6 @@
   animation: leaflet-control-locate-throb 4s ease infinite;
 }
 
-.leaflet-control-locate-heading-arrow {
-  transform: rotate(0deg);
-}
-
 @keyframes leaflet-control-locate-throb {
   0% {
     stroke-width: 1;


### PR DESCRIPTION
Using transform on the `<svg>` element is not supported by Firefox or Safari: https://caniuse.com/mdn-svg_global_attributes_transform_svg_root

Therefore, this has not worked since PR #368 / commit 4cd1349a738ee2986e6341e05b846b6e491cc585.

Using style/CSS works though, as it was before PR #364 / commit e2d60a58b39ebffff86ec1378b4c374caf1016bd

I tried some workarounds on the svg by adding a `<g>` element with rotation, but I did not get it to work as expected. I gave up and went back to using CSS.

Since the point of #364 was to avoid inline styles to allow strict Content Security Policies, I found a way to update the style without using the `style` attribute, but instead using a class name and editing the style associated with it. This works, and you can use this with style-src 'self' in the CSP.

Fixes #370