### PR TITLE
refactor(dev): replace `grunt-contrib-connect` with native Node.js server

### DIFF
--- a/Gruntfile.cjs
+++ b/Gruntfile.cjs
@@ -24,20 +24,10 @@ module.exports = function (grunt) {
         ],
         push: false
       }
-    },
-    connect: {
-      server: {
-        options: {
-          port: 9000,
-          protocol: "https",
-          keepalive: true
-        }
-      }
     }
   });
 
   grunt.loadNpmTasks("grunt-bump");
-  grunt.loadNpmTasks("grunt-contrib-connect");
 
   // Default task(s).
   grunt.registerTask("default", []);

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ Please check for [breaking changes in the changelog](https://github.com/domoritz
 
 ## Demo
 
-- [Demo with Leaflet](https://domoritz.github.io/leaflet-locatecontrol/demo/)
-- [Demo with Mapbox.js](https://domoritz.github.io/leaflet-locatecontrol/demo_mapbox/)
+Check out the [demo page](https://domoritz.github.io/leaflet-locatecontrol/) with three different examples (Leaflet UMD, Leaflet ESM, Mapbox UMD).
 
 ## Basic Usage
 
-### Set up:
+### Set up
 
 1. Get CSS and JavaScript files
 2. Include CSS and JavaScript files
@@ -230,9 +229,11 @@ let map = new L.Map('map', {
 
 ## Developers
 
-Run the demo locally with `yarn start` or `npm run start` and then open [localhost:9000/demo/index.html](http://localhost:9000/demo/index.html).
+Run the demo locally with `npm start` and then open [http://localhost:9000](http://localhost:9000).
 
-To generate the minified JS and CSS files, use [grunt](http://gruntjs.com/getting-started) and run `grunt`. However, don't include new minified files or a new version as part of a pull request. If you need SASS, install it with `brew install sass/sass/sass`.
+The development server is a native Node.js script (`scripts/server.js`) that serves the project on port 9000. It does not require any external dependencies. Note that modern browsers treat `localhost` as a secure context, so HTTPS is not required for the Geolocation API to work.
+
+To generate the minified JS and CSS files, run `npm run build`.
 
 ## Prettify and linting
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-const eslintPluginPrettierRecommended = require("eslint-plugin-prettier/recommended");
-const globals = require("globals");
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import globals from "globals";
 
-module.exports = [
+export default [
   {
     files: ["**/*.js"],
     languageOptions: {

--- a/index.html
+++ b/index.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>leaflet-locatecontrol</title>
+    <style>
+      :root {
+        --bg: #0a0e13;
+        --bg-subtle: #0f1419;
+        --text: #e6edf3;
+        --text-muted: #8b949e;
+        --link: #58a6ff;
+        --link-hover: #79c0ff;
+        --border: #21262d;
+        --accent: #238636;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font:
+          16px/1.6 -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          "Helvetica Neue",
+          Arial,
+          sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+
+      a {
+        color: var(--link);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      a:hover {
+        color: var(--link-hover);
+      }
+
+      .container {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 0 24px;
+      }
+
+      header {
+        padding: 64px 0 48px;
+      }
+
+      .header-content {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 48px;
+        align-items: center;
+      }
+
+      h1 {
+        margin: 0 0 24px;
+        font-size: 48px;
+        font-weight: 600;
+        letter-spacing: -0.025em;
+        background: linear-gradient(135deg, #e6edf3 0%, #8b949e 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+
+      .header-description {
+        color: var(--text-muted);
+        font-size: 17px;
+        line-height: 1.7;
+      }
+
+      .header-description p {
+        margin: 0 0 16px;
+      }
+
+      .header-description p:last-child {
+        margin-bottom: 0;
+      }
+
+      .hero {
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 4px 32px rgba(0, 0, 0, 0.4);
+        transition:
+          transform 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+
+      .hero:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 48px rgba(0, 0, 0, 0.5);
+      }
+
+      .hero img {
+        width: 100%;
+        height: auto;
+        display: block;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+      }
+
+      main {
+        padding-bottom: 80px;
+      }
+
+      h2 {
+        margin: 0 0 32px;
+        font-size: 28px;
+        font-weight: 600;
+        text-align: center;
+        color: var(--text);
+      }
+
+      .examples {
+        list-style: none;
+        padding: 0;
+        margin: 0 0 64px 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 16px;
+      }
+
+      .examples li {
+        margin: 0;
+      }
+
+      .examples a {
+        display: block;
+        padding: 16px 20px;
+        background: var(--bg-subtle);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--text);
+        transition: all 0.2s ease;
+      }
+
+      .examples a:hover {
+        border-color: var(--link);
+        background: rgba(88, 166, 255, 0.05);
+        transform: translateX(4px);
+        color: var(--link-hover);
+      }
+
+      .example-number {
+        color: var(--text-muted);
+        font-size: 0.85em;
+        margin-right: 8px;
+        font-weight: 500;
+      }
+
+      code {
+        background: rgba(110, 118, 129, 0.15);
+        border: 1px solid var(--border);
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.9em;
+        font-family: "SF Mono", Monaco, "Cascadia Mono", "Roboto Mono", Consolas, monospace;
+      }
+
+      @media (max-width: 768px) {
+        .header-content {
+          grid-template-columns: 1fr;
+          gap: 32px;
+        }
+
+        h1 {
+          font-size: 36px;
+        }
+
+        header {
+          padding: 48px 0 32px;
+        }
+
+        .header-description {
+          font-size: 16px;
+        }
+
+        h2 {
+          font-size: 24px;
+          margin-bottom: 24px;
+        }
+
+        .examples {
+          grid-template-columns: 1fr;
+          gap: 12px;
+        }
+      }
+    </style>
+    <meta name="description" content="A useful control to geolocate the user with many options. Used by osm.org and mapbox among many others." />
+    <meta property="og:title" content="leaflet-locatecontrol" />
+    <meta property="og:description" content="A useful control to geolocate the user with many options. Used by osm.org and mapbox among many others." />
+    <meta property="og:image" content="screenshot.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <div class="header-content">
+          <div class="header-left">
+            <h1>leaflet-locatecontrol</h1>
+            <div class="header-description">
+              <p>
+                A useful control to geolocate the user with many options. Used by osm.org and mapbox among many others.
+              </p>
+              <p>
+                MIT Licensed – View on <a href="https://github.com/domoritz/leaflet-locatecontrol" target="_blank" rel="noopener">GitHub</a> or read the
+                <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet documentation</a>.
+              </p>
+            </div>
+          </div>
+          <div class="hero">
+            <img src="screenshot.png" alt="leaflet-locatecontrol example map screenshot" />
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="container">
+      <h2>Demos</h2>
+      <ul class="examples">
+        <li>
+          <a href="demo/"><span class="example-number">1.</span> Leaflet UMD</a>
+        </li>
+        <li>
+          <a href="demo_esm/"><span class="example-number">2.</span> Leaflet ESM</a>
+        </li>
+        <li>
+          <a href="demo_mapbox/"><span class="example-number">3.</span> Mapbox UMD</a>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -96,11 +96,6 @@
           box-shadow 0.3s ease;
       }
 
-      .hero:hover {
-        transform: translateY(-4px);
-        box-shadow: 0 8px 48px rgba(0, 0, 0, 0.5);
-      }
-
       .hero img {
         width: 100%;
         height: auto;

--- a/index.html
+++ b/index.html
@@ -205,9 +205,7 @@
           <div class="header-left">
             <h1>leaflet-locatecontrol</h1>
             <div class="header-description">
-              <p>
-                A useful control to geolocate the user with many options. Used by osm.org and mapbox among many others.
-              </p>
+              <p>A useful control to geolocate the user with many options. Used by osm.org and mapbox among many others.</p>
               <p>
                 MIT Licensed – View on <a href="https://github.com/domoritz/leaflet-locatecontrol" target="_blank" rel="noopener">GitHub</a> or read the
                 <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet documentation</a>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "eslint-plugin-prettier": "^5.2.5",
         "grunt": "^1.6.1",
         "grunt-bump": "0.8.0",
-        "grunt-contrib-connect": "^5.0.1",
         "leaflet": "^1.9.4",
         "prettier": "^3.5.3",
         "rollup": "^4.53.3",
@@ -1049,18 +1048,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1165,7 +1152,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1193,22 +1182,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/batch": {
-      "version": "0.6.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -1374,28 +1347,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/connect": {
-      "version": "3.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.2",
-        "parseurl": "~1.3.3",
-        "utils-merge": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/connect-livereload": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "dev": true,
@@ -1497,14 +1448,6 @@
         "node": "*"
       }
     },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -1516,31 +1459,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-file": {
@@ -1576,25 +1494,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -1611,11 +1516,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -1892,14 +1792,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/eventemitter2": {
       "version": "0.4.14",
       "dev": true,
@@ -2012,23 +1904,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
@@ -2117,14 +1992,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2320,27 +2187,6 @@
         "nopt": "bin/nopt.js"
       }
     },
-    "node_modules/grunt-contrib-connect": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-5.0.1.tgz",
-      "integrity": "sha512-Hfq/0QJl3ddD2N/a/1cDJHkKEOGk6m7W6uxNe0AmYwtf6v0F/4+8q9rvPJ1tl+mrI90lU/89I9T/h48qqeMfQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.5",
-        "connect": "^3.7.0",
-        "connect-livereload": "^0.6.1",
-        "http2-wrapper": "^2.2.1",
-        "morgan": "^1.10.0",
-        "open": "^8.0.0",
-        "portscanner": "^2.2.0",
-        "serve-index": "^1.9.1",
-        "serve-static": "^1.15.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/grunt-known-options": {
       "version": "2.0.0",
       "dev": true,
@@ -2499,47 +2345,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/http-errors": {
-      "version": "1.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/inherits": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/http2-wrapper": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "dev": true,
@@ -2670,20 +2475,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -2724,14 +2515,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-like": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lodash.isfinite": "^3.3.2"
       }
     },
     "node_modules/is-plain-object": {
@@ -2781,17 +2564,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isexe": {
@@ -2943,11 +2715,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.isfinite": {
-      "version": "3.3.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
@@ -3034,36 +2801,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -3074,28 +2811,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3120,14 +2835,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
@@ -3193,49 +2900,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/on-headers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -3356,14 +3026,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -3438,27 +3100,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/portscanner": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.0",
-        "is-number-like": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=0.4",
-        "npm": ">=1.0.0"
-      }
-    },
-    "node_modules/portscanner/node_modules/async": {
-      "version": "2.6.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/postcss": {
@@ -3639,19 +3280,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -3660,14 +3288,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/readdirp": {
@@ -3720,13 +3340,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/resolve-dir": {
       "version": "1.0.1",
@@ -3888,73 +3501,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/send": {
-      "version": "0.19.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/http-errors": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/send/node_modules/on-finished": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/send/node_modules/statuses": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -3964,50 +3510,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/serve-index": {
-      "version": "1.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "batch": "0.6.1",
-        "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "1.16.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-static/node_modules/encodeurl": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4111,14 +3613,6 @@
       "version": "1.1.3",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4562,14 +4056,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4622,14 +4108,6 @@
         "node": "*"
       }
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4644,14 +4122,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/v8flags": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bump:patch": "grunt --gruntfile Gruntfile.cjs bump-only:patch && npm run build && grunt --gruntfile Gruntfile.cjs bump-commit",
     "lint": "eslint && stylelint {**/style.css,**/*.scss} && prettier --check .",
     "lint:fix": "eslint --fix && stylelint --fix {**/style.css,**/*.scss} && prettier --write .",
-    "start": "grunt --gruntfile Gruntfile.cjs connect"
+    "start": "node scripts/server.js"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^29.0.0",
@@ -41,7 +41,6 @@
     "eslint-plugin-prettier": "^5.2.5",
     "grunt": "^1.6.1",
     "grunt-bump": "0.8.0",
-    "grunt-contrib-connect": "^5.0.1",
     "leaflet": "^1.9.4",
     "prettier": "^3.5.3",
     "rollup": "^4.53.3",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,0 +1,55 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PORT = 9000;
+const ROOT = process.cwd();
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+};
+
+const server = http.createServer((req, res) => {
+  console.log(`${req.method} ${req.url}`);
+
+  // Einfacher Schutz gegen Directory Traversal
+  const safePath = path.normalize(req.url).replace(/^(\.\.[\/\\])+/, '');
+  let filePath = path.join(ROOT, safePath);
+
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('404 Not Found');
+      return;
+    }
+
+    // Wenn es ein Ordner ist, suche nach index.html
+    if (stats.isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('404 Not Found');
+        return;
+      }
+
+      const ext = path.extname(filePath).toLowerCase();
+      const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(data);
+    });
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}/`);
+  console.log('Hit CTRL-C to stop the server');
+});

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,52 +1,52 @@
-import http from 'node:http';
-import fs from 'node:fs';
-import path from 'node:path';
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
 
 const PORT = 9000;
 const ROOT = process.cwd();
 
 const MIME_TYPES = {
-  '.html': 'text/html',
-  '.js': 'text/javascript',
-  '.css': 'text/css',
-  '.json': 'application/json',
-  '.png': 'image/png',
-  '.ico': 'image/x-icon',
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".ico": "image/x-icon"
 };
 
 const server = http.createServer((req, res) => {
   console.log(`${req.method} ${req.url}`);
 
-  let filePath = path.join(ROOT, req.url.split('?')[0]);
+  let filePath = path.join(ROOT, req.url.split("?")[0]);
 
   fs.stat(filePath, (err, stats) => {
     if (err) {
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end('404 Not Found');
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("404 Not Found");
       return;
     }
 
     // If it is a directory, look for index.html
     if (stats.isDirectory()) {
-      filePath = path.join(filePath, 'index.html');
+      filePath = path.join(filePath, "index.html");
     }
 
     fs.readFile(filePath, (err, data) => {
       if (err) {
-        res.writeHead(404, { 'Content-Type': 'text/plain' });
-        res.end('404 Not Found');
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("404 Not Found");
         return;
       }
 
       const ext = path.extname(filePath).toLowerCase();
-      const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+      const contentType = MIME_TYPES[ext] || "application/octet-stream";
 
-      res.writeHead(200, { 'Content-Type': contentType });
+      res.writeHead(200, { "Content-Type": contentType });
       res.end(data);
     });
   });
 });
 
-server.listen(PORT, 'localhost', () => {
+server.listen(PORT, "localhost", () => {
   console.log(`Server running at http://localhost:${PORT}/`);
 });

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -17,9 +17,7 @@ const MIME_TYPES = {
 const server = http.createServer((req, res) => {
   console.log(`${req.method} ${req.url}`);
 
-  // Einfacher Schutz gegen Directory Traversal
-  const safePath = path.normalize(req.url).replace(/^(\.\.[\/\\])+/, '');
-  let filePath = path.join(ROOT, safePath);
+  let filePath = path.join(ROOT, req.url.split('?')[0]);
 
   fs.stat(filePath, (err, stats) => {
     if (err) {
@@ -28,7 +26,7 @@ const server = http.createServer((req, res) => {
       return;
     }
 
-    // Wenn es ein Ordner ist, suche nach index.html
+    // If it is a directory, look for index.html
     if (stats.isDirectory()) {
       filePath = path.join(filePath, 'index.html');
     }
@@ -49,7 +47,6 @@ const server = http.createServer((req, res) => {
   });
 });
 
-server.listen(PORT, () => {
+server.listen(PORT, 'localhost', () => {
   console.log(`Server running at http://localhost:${PORT}/`);
-  console.log('Hit CTRL-C to stop the server');
 });

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -41,8 +41,8 @@ const LocationMarker = Marker.extend({
       ["fill-opacity", opt.fillOpacity],
       ["opacity", opt.opacity]
     ]
-      .filter(([k,v]) => v !== undefined)
-      .map(([k,v]) => `${k}="${v}"`)
+      .filter(([k, v]) => v !== undefined)
+      .map(([k, v]) => `${k}="${v}"`)
       .join(" ");
 
     const icon = this._getIconSVG(opt, style);


### PR DESCRIPTION
This PR removes the `grunt-contrib-connect` dependency and replaces it with a lightweight native Node.js server script.

### Changes

- Remove `grunt-contrib-connect` dependency in favor of custom `scripts/server.js`
- Add `index.html` landing page to showcase all three demos
- Update `README.md` with simplified demo section and developer instructions

### Benefits

- **Zero external dependencies** for the dev server
- **Better experience for users and developers** with a central landing page for all demos

### Testing

```bash
npm start
# Visit http://localhost:9000