### PR TITLE
feat: add zoom range support to `keepCurrentZoomLevel` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `layer` | [`ILayer`](http://leafletjs.com/reference.html#ilayer)  | The layer that the user's location should be drawn on. | a new layer |
 | `setView` | `boolean`  or `string`  | Set the map view (zoom and pan) to the user's location as it updates. Options are `false`, `'once'`, `'always'`, `'untilPan'`, or `'untilPanOrZoom'` | `'untilPanOrZoom'` |
 | `flyTo` | `boolean` | Smooth pan and zoom to the location of the marker. Only works in Leaflet 1.0+. | `false` |
-| `keepCurrentZoomLevel` | `boolean`  | Only pan when setting the view. | `false` |
+| `keepCurrentZoomLevel` | `boolean` or `Array`  | Only pan when setting the view. Set to `true` to always keep the current zoom, or provide a zoom range like `[13, 18]` to only keep the zoom when it's within that range. Outside the range, the map will zoom normally. | `false` |
 | `initialZoomLevel` | `false` or `integer` | After activating the plugin by clicking on the icon, zoom to the selected zoom level, even when keepCurrentZoomLevel is true. Set to `false` to disable this feature. | `false` |
 | `clickBehavior` | `object`  | What to do when the user clicks on the control. Has three options `inView`, `inViewNotFollowing` and `outOfView`. Possible values are `stop` and `setView`, or the name of a behaviour to inherit from. | `{inView: 'stop', outOfView: 'setView', inViewNotFollowing: 'inView'}` |
 | `returnToPrevBounds` | `boolean`  | If set, save the map bounds just before centering to the user's location. When control is disabled, set the view back to the bounds that were saved. | `false` |
@@ -200,13 +200,26 @@ var lc = new L.Control.MyLocate();
 
 #### How do I set the maximum zoom level?
 
-Set the `maxZoom` in `locateOptions` (`keepCurrentZoomLevel` must not be set to true).
+Set the `maxZoom` in `locateOptions` (only applies when `keepCurrentZoomLevel` is `false` or when the current zoom is outside a specified range).
 
 ```js
 map.addControl(
   L.control.locate({
     locateOptions: {
       maxZoom: 10
+    }
+  })
+);
+```
+
+You can also use `keepCurrentZoomLevel: [13, 18]` to only keep zoom when it's between levels 13-18, but zoom normally outside that range:
+
+```js
+map.addControl(
+  L.control.locate({
+    keepCurrentZoomLevel: [13, 18],
+    locateOptions: {
+      maxZoom: 16
     }
   })
 );

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -166,7 +166,13 @@ const LocateControl = Control.extend({
      *                The map view follows the user's location until she pans.
      */
     setView: "untilPanOrZoom",
-    /** Keep the current map zoom level when setting the view and only pan. */
+    /**
+     * Keep the current map zoom level when setting the view and only pan.
+     * Can be set to:
+     * - `true`: Always keep current zoom level
+     * - `false`: Allow zooming (default)
+     * - `[minZoom, maxZoom]`: Keep zoom only when current zoom is within the specified range
+     */
     keepCurrentZoomLevel: false,
     /** After activating the plugin by clicking on the icon, zoom to the selected zoom level, even when keepCurrentZoomLevel is true. Set to 'false' to disable this feature. */
     initialZoomLevel: false,
@@ -547,6 +553,24 @@ const LocateControl = Control.extend({
   },
 
   /**
+   * Check if the current zoom level should be kept based on keepCurrentZoomLevel option.
+   * @returns {boolean} true if zoom should be kept, false otherwise
+   */
+  _shouldKeepCurrentZoom() {
+    const option = this.options.keepCurrentZoomLevel;
+
+    // If option is an array [minZoom, maxZoom], check if current zoom is within range
+    if (Array.isArray(option) && option.length === 2) {
+      const currentZoom = this._map.getZoom();
+      const [minZoom, maxZoom] = option;
+      return currentZoom >= minZoom && currentZoom <= maxZoom;
+    }
+
+    // Only return true if explicitly set to true
+    return option === true;
+  },
+
+  /**
    * Zoom (unless we should keep the zoom level) and an to the current view.
    */
   setView() {
@@ -558,7 +582,7 @@ const LocateControl = Control.extend({
       if (this._justClicked && this.options.initialZoomLevel !== false) {
         let f = this.options.flyTo ? this._map.flyTo : this._map.setView;
         f.bind(this._map)([this._event.latitude, this._event.longitude], this.options.initialZoomLevel);
-      } else if (this.options.keepCurrentZoomLevel) {
+      } else if (this._shouldKeepCurrentZoom()) {
         let f = this.options.flyTo ? this._map.flyTo : this._map.panTo;
         f.bind(this._map)([this._event.latitude, this._event.longitude]);
       } else {


### PR DESCRIPTION
Add support for array syntax in `keepCurrentZoomLevel` option to allow specifying a zoom range like `[13, 18]`. When the current zoom is within this range, the map only pans. Outside the range, it zooms normally.

Changes:
- Extract zoom-keeping logic into `_shouldKeepCurrentZoom()` helper
- Support three modes: `false` (default), `true` (always), or `[min, max]`
- Update README with usage examples and clarified `maxZoom` behavior

This implements the feature originally requested in #246 and supersedes the stale PR #247 from 2019. This implementation uses a dedicated helper method for better testability and maintainability.