### PR TITLE
feat: stop locate when control is removed from map

### DIFF
--- a/src/L.Control.Locate.d.ts
+++ b/src/L.Control.Locate.d.ts
@@ -56,6 +56,8 @@ export class LocateControl extends Control {
 
   onAdd(map: Map): HTMLElement;
 
+  onRemove(): void;
+
   start(): void;
 
   stop(): void;

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -380,6 +380,13 @@ const LocateControl = Control.extend({
   },
 
   /**
+   * Called when control is removed from the map.
+   */
+  onRemove() {
+    this.stop()
+  },
+
+  /**
    * This method is called when the user clicks on the control.
    */
   _onClick() {


### PR DESCRIPTION
If there is an active location when the control is removed from the map, let's call stop to deactivate it, and remove event listeners (zoomEnd…).

Thanks!