### PR TITLE
Improve timeout handling in watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A useful control to geolocate the user with many options. Official [Leaflet](http://leafletjs.com/plugins.html#geolocation) and [MapBox plugin](https://www.mapbox.com/mapbox.js/example/v1.0.0/leaflet-locatecontrol/).
 
-Tested with [Leaflet](http://leafletjs.com/) 1.9.2 and [Mapbox.js](https://docs.mapbox.com/mapbox.js/) 3.3.1 in Firefox, Chrome and Safari.
+Tested with [Leaflet](https://leafletjs.com/) 1.9.2 and [Mapbox.js](https://docs.mapbox.com/mapbox.js/) 3.3.1 in Firefox, Chrome and Safari.
 
 Please check for [breaking changes in the changelog](https://github.com/domoritz/leaflet-locatecontrol/blob/gh-pages/CHANGELOG.md).
 
@@ -81,7 +81,7 @@ L.control.locate().addTo(map);
 
 ### Possible options
 
-The locate controls inherits options from [Leaflet Controls](http://leafletjs.com/reference.html#control-options).
+The locate controls inherits options from [Leaflet Controls](https://leafletjs.com/reference.html#control).
 
 To customize the control, pass an object with your custom options to the locate control.
 
@@ -126,7 +126,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `showPopup` | `boolean`  | Display a pop-up when the user click on the inner marker. | `true` |
 | `strings` | `object`  | Strings used in the control. Options are `title`, `text`, `metersUnit`, `feetUnit`, `popup` and `outsideMapBoundsMsg` | see code |
 | `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}` and `{unit}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit}` and expected to return a string. | see code |
-| `locateOptions` | [`Locate options`](http://leafletjs.com/reference.html#map-locate-options)  | The default options passed to leaflets locate method. | see code |
+| `locateOptions` | [`Locate options`](https://leafletjs.com/reference.html#locate-options)  | The default options passed to leaflets locate method. | see code |
 <!-- prettier-ignore-end -->
 
 For example, to customize the position and the title, you could write
@@ -150,10 +150,10 @@ var lc = L.control
 
 Sites that use this locate control:
 
-- [OpenStreetMap](http://www.openstreetmap.org/) on the start page
+- [OpenStreetMap](https://www.openstreetmap.org/) on the start page
 - [MapBox](https://www.mapbox.com/mapbox.js/example/v1.0.0/leaflet-locatecontrol/)
-- [wheelmap.org](http://wheelmap.org/map)
-- [OpenMensa](http://openmensa.org/)
+- [wheelmap.org](https://wheelmap.org/)
+- [OpenMensa](https://openmensa.org/)
 - [Maps Marker Pro](https://www.mapsmarker.com) (WordPress plugin)
 - [Bikemap](https://jackdougherty.github.io/bikemapcode/)
 - [MyRoutes](https://myroutes.io/)
@@ -178,9 +178,20 @@ You can keep the plugin active but stop following using `lc.stopFollowing()`.
 
 ### Events
 
-You can leverage the native Leaflet events `locationfound` and `locationerror` to handle when geolocation is successful or produces an error. You can find out more about these events in the [Leaflet documentation](http://leafletjs.com/examples/mobile.html#geolocation).
+You can leverage the native Leaflet events `locationfound` and `locationerror` to handle when geolocation is successful or produces an error. You can find out more about these events in the [Leaflet documentation](https://leafletjs.com/examples/mobile/#geolocation).
 
 Additionally, the locate control fires `locateactivate` and `locatedeactivate` events on the map object when it is activated and deactivated, respectively.
+
+The control also fires a `locationtimeout` event when geolocation timeouts occur in watch mode. This is useful for providing custom feedback to users when location acquisition takes longer than expected:
+
+```js
+map.on("locationtimeout", function (e) {
+  console.log("Location timeout count:", e.count);
+  // Provide custom feedback or retry logic
+});
+```
+
+Note: When `watch: true` (the default), timeout errors don't stop the location tracking - the browser will automatically retry. After 3 consecutive timeouts, the control displays a visual indicator (orange spinner) to inform users that location acquisition is taking longer than usual.
 
 ### Extending
 
@@ -227,7 +238,7 @@ map.addControl(
 
 #### How do I enable high accuracy?
 
-To enable [high accuracy (GPS) mode](http://leafletjs.com/reference.html#map-enablehighaccuracy), set the `enableHighAccuracy` in `locateOptions`.
+To enable [high accuracy (GPS) mode](https://leafletjs.com/reference.html#locate-options-enablehighaccuracy), set the `enableHighAccuracy` in `locateOptions`.
 
 ```js
 map.addControl(

--- a/demo/test-timeout.html
+++ b/demo/test-timeout.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Locate Control - Poor GPS Signal Demo</title>
+    <link rel="icon" href="../favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="../dist/L.Control.Locate.css" />
+    <style>
+      :root {
+        --bg-color: #fff;
+        --text-color: #212529;
+        --border-color: #dee2e6;
+        --console-bg: #1e1e1e;
+        --console-color: #d4d4d4;
+        --button-border: #ccc;
+        --leaflet-bar-bg: #fff;
+        --leaflet-bar-color: #000;
+        --leaflet-bar-border: rgba(0, 0, 0, 0.2);
+        --leaflet-bar-hover-bg: #f4f4f4;
+        --leaflet-attribution-bg: rgba(255, 255, 255, 0.7);
+        --leaflet-attribution-color: #333;
+      }
+
+      :root[data-theme="dark"] {
+        color-scheme: dark;
+        --bg-color: #1a1a1a;
+        --text-color: #f0f0f0;
+        --border-color: #404040;
+        --console-bg: #0d0d0d;
+        --console-color: #e0e0e0;
+        --button-border: #555;
+        --leaflet-bar-bg: #3a3a3a;
+        --leaflet-bar-color: #fff;
+        --leaflet-bar-border: rgba(255, 255, 255, 0.2);
+        --leaflet-bar-hover-bg: #555;
+        --leaflet-attribution-bg: rgba(58, 58, 58, 0.8);
+        --leaflet-attribution-color: #fff;
+      }
+
+      body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+        background: var(--bg-color);
+        color: var(--text-color);
+        transition:
+          background-color 0.3s ease,
+          color 0.3s ease;
+      }
+      #map {
+        height: 100vh;
+      }
+      #description {
+        background: #f8f9fa;
+        padding: 20px;
+        border-bottom: 2px solid #dee2e6;
+      }
+      :root[data-theme="dark"] #description {
+        background: #2d2d30;
+        border-bottom-color: #404040;
+      }
+      #description h2 {
+        margin: 0 0 15px 0;
+        color: var(--text-color);
+        font-size: 24px;
+      }
+      #description p {
+        margin: 0 0 12px 0;
+        color: var(--text-color);
+        line-height: 1.6;
+      }
+      #description code {
+        background: rgba(0, 0, 0, 0.1);
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-family: "Courier New", monospace;
+      }
+      :root[data-theme="dark"] #description code {
+        background: rgba(255, 255, 255, 0.15);
+      }
+      #dark-mode-toggle {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 1000;
+        padding: 8px 15px;
+        background: white;
+        border: 2px solid var(--button-border);
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        transition:
+          background-color 0.3s ease,
+          color 0.3s ease;
+      }
+      :root[data-theme="dark"] #dark-mode-toggle {
+        background: #2d2d30;
+        color: #cccccc;
+        border-color: #555;
+      }
+
+      /* Leaflet controls dark mode */
+      :root[data-theme="dark"] .leaflet-bar a {
+        background: var(--leaflet-bar-bg);
+        color: var(--leaflet-bar-color);
+        border-color: var(--leaflet-bar-border);
+      }
+      :root[data-theme="dark"] .leaflet-bar a:hover,
+      :root[data-theme="dark"] .leaflet-bar a:focus {
+        background: var(--leaflet-bar-hover-bg);
+      }
+      :root[data-theme="dark"] .leaflet-control-attribution {
+        background: var(--leaflet-attribution-bg) !important;
+        color: var(--leaflet-attribution-color) !important;
+      }
+
+      /* Tile filter for dark mode */
+      :root[data-theme="dark"] .leaflet-tile-pane {
+        filter: invert(1) hue-rotate(180deg) brightness(0.95) saturate(0.85);
+      }
+
+      /* Locate control icon color in dark mode */
+      :root[data-theme="dark"] .leaflet-control-locate {
+        --locate-control-icon-color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="dark-mode-toggle" onclick="toggleDarkMode()">🌙 Dark Mode</button>
+    <div id="description">
+      <h2>Poor GPS Signal Demo</h2>
+      <p>
+        This demo simulates <strong>poor GPS reception</strong> (e.g., indoors, tunnels, urban canyons) to showcase how the locate control handles repeated
+        timeouts gracefully in watch mode.
+      </p>
+      <p style="font-size: 14px; color: #6c757d">
+        <strong>Configuration:</strong> This demo uses a <strong>5 second timeout</strong> (realistic for GPS). After
+        <strong>3 consecutive timeouts</strong> (~15 seconds), the spinner turns <strong style="color: #f39c12">orange</strong>
+        to indicate signal issues. The control keeps trying without interrupting the user experience.
+      </p>
+      <p style="font-size: 14px; color: #6c757d">
+        <strong>For developers:</strong> Listen to the <code>locationtimeout</code> event if you want to inform users about signal issues additional to the
+        visual feedback provided by the control:
+        <code style="display: block; margin-top: 8px; padding: 8px; background: rgba(0, 0, 0, 0.05)"
+          >map.on('locationtimeout', (e) => alert(`GPS timeout ${e.count}`));</code
+        >
+      </p>
+    </div>
+    <div id="map"></div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="../dist/L.Control.Locate.umd.js"></script>
+    <script>
+      function log(message, type = "info") {
+        const prefix =
+          {
+            info: "[INFO]   ",
+            success: "[SUCCESS]",
+            warning: "[WARNING]",
+            error: "[ERROR]  ",
+            event: "[EVENT]  "
+          }[type] || "[INFO]   ";
+        console.log(`${prefix} ${message}`);
+      }
+
+      const map = L.map("map").setView([51.505, -0.09], 13);
+      L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution: "&copy; OpenStreetMap"
+      }).addTo(map);
+
+      log("Map initialized", "success");
+
+      // Locate Control with moderate timeout for testing
+      // Standard Geolocation API: timeout = Infinity (no timeout)
+      // Here: 5000ms = realistic for slow GPS
+      const lc = L.control
+        .locate({
+          locateOptions: {
+            timeout: 5000,
+            maximumAge: 0,
+            enableHighAccuracy: false,
+            watch: true
+          },
+          strings: {
+            title: "Show my location"
+          }
+        })
+        .addTo(map);
+
+      log("Locate Control created (timeout: 5000ms, watch: true)", "info");
+
+      // Event listeners
+      map.on("locationfound", (e) => {
+        log(`locationfound - ${e.latlng.lat.toFixed(5)}, ${e.latlng.lng.toFixed(5)}`, "success");
+      });
+
+      map.on("locationerror", (e) => {
+        const errorTypes = { 1: "PERMISSION_DENIED", 2: "POSITION_UNAVAILABLE", 3: "TIMEOUT" };
+        log(`locationerror - Code ${e.code} (${errorTypes[e.code]}): ${e.message}`, "error");
+      });
+
+      // New locationtimeout event
+      let visualFeedbackActive = false;
+      map.on("locationtimeout", (e) => {
+        log(`locationtimeout EVENT - Count: ${e.count}`, "event");
+        if (e.count >= 3 && !visualFeedbackActive) {
+          visualFeedbackActive = true;
+          log("Visual feedback active (orange spinner)", "warning");
+        }
+      });
+
+      map.on("locateactivate", () => {
+        log("locateactivate - Geolocation started", "info");
+        visualFeedbackActive = false;
+      });
+
+      map.on("locatedeactivate", () => {
+        log("locatedeactivate - Geolocation stopped", "warning");
+      });
+
+      log("Event listeners registered", "info");
+      log("Demo ready - Simulating poor GPS signal", "info");
+
+      // Simulate poor GPS signal (timeout errors)
+      const activeWatchers = new Map();
+      let callCount = 0;
+
+      navigator.geolocation.watchPosition = function (success, error, options) {
+        callCount++;
+        const watchId = callCount;
+        log(`watchPosition (#${watchId}) timeout: ${options.timeout}ms`, "info");
+
+        // Simulate timeout at the configured interval
+        const intervalId = setInterval(() => {
+          if (!activeWatchers.has(watchId)) {
+            clearInterval(intervalId);
+            return;
+          }
+          log(`Timeout triggered (Watch #${watchId})`, "warning");
+          error({ code: 3, message: "Timeout (simulated)", TIMEOUT: 3 });
+        }, options.timeout || 5000);
+
+        activeWatchers.set(watchId, intervalId);
+        return watchId;
+      };
+
+      navigator.geolocation.clearWatch = function (watchId) {
+        if (activeWatchers.has(watchId)) {
+          clearInterval(activeWatchers.get(watchId));
+          activeWatchers.delete(watchId);
+          log(`clearWatch (#${watchId})`, "info");
+        }
+      };
+
+      log("Poor GPS signal simulation active", "warning");
+
+      // Dark mode toggle
+      const root = document.documentElement;
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const savedTheme = localStorage.getItem("theme");
+
+      if (savedTheme) {
+        root.setAttribute("data-theme", savedTheme);
+      } else if (prefersDark) {
+        root.setAttribute("data-theme", "dark");
+      }
+
+      function getCurrentTheme() {
+        const dataTheme = root.getAttribute("data-theme");
+        if (dataTheme) return dataTheme;
+        return prefersDark ? "dark" : "light";
+      }
+
+      function toggleDarkMode() {
+        const currentTheme = getCurrentTheme();
+        const newTheme = currentTheme === "dark" ? "light" : "dark";
+        root.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+        document.getElementById("dark-mode-toggle").textContent = newTheme === "dark" ? "☀️ Light Mode" : "🌙 Dark Mode";
+      }
+
+      // Update button text on load
+      if (getCurrentTheme() === "dark") {
+        document.getElementById("dark-mode-toggle").textContent = "☀️ Light Mode";
+      }
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
     </header>
 
     <main class="container">
-      <h2>Demos</h2>
+      <h2>Implementation Examples</h2>
       <ul class="examples">
         <li>
           <a href="demo/umd/">Leaflet UMD</a>
@@ -265,6 +265,13 @@
         </li>
         <li>
           <a href="demo/mapbox/">Mapbox UMD</a>
+        </li>
+      </ul>
+
+      <h2>Feature Showcase</h2>
+      <ul class="examples">
+        <li>
+          <a href="demo/test-timeout.html">Poor GPS Signal Handling</a>
         </li>
       </ul>
     </main>

--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -32,6 +32,11 @@
   &.following a .leaflet-control-locate-location-arrow {
     background-color: var(--locate-control-following-color);
   }
+
+  /* Visual feedback when location timeouts occur repeatedly */
+  &.locate-timeout a .leaflet-control-locate-spinner {
+    background-color: #f39c12; /* Orange to indicate slower location acquisition */
+  }
 }
 
 .leaflet-touch .leaflet-bar .leaflet-locate-text-active {

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -763,11 +763,27 @@ const LocateControl = Control.extend({
    * Calls deactivate and dispatches an error.
    */
   _onLocationError(err) {
-    // ignore time out error if the location is watched
-    if (err.code == 3 && this.options.locateOptions.watch) {
+    // Handle timeout errors in watch mode differently
+    if (err.code === 3 && this.options.locateOptions.watch) {
+      this._timeoutCount = (this._timeoutCount || 0) + 1;
+
+      // Fire event for developers to handle timeouts
+      this._map.fire("locationtimeout", {
+        error: err,
+        control: this,
+        count: this._timeoutCount
+      });
+
+      // Visual feedback after repeated timeouts
+      if (this._timeoutCount >= 3 && this._container) {
+        addClasses(this._container, "locate-timeout");
+      }
+
       return;
     }
 
+    // Reset timeout counter for other errors
+    this._timeoutCount = 0;
     this.stop();
     this.options.onLocationError(err, this);
   },
@@ -784,6 +800,12 @@ const LocateControl = Control.extend({
     if (!this._active) {
       // we may have a stray event
       return;
+    }
+
+    // Reset timeout counter on successful location
+    this._timeoutCount = 0;
+    if (this._container) {
+      removeClasses(this._container, "locate-timeout");
     }
 
     this._event = e;
@@ -954,6 +976,14 @@ const LocateControl = Control.extend({
     // true if the control was clicked for the first time
     // we need this so we can pan and zoom once we have the location
     this._justClicked = false;
+
+    // timeout counter for visual feedback
+    this._timeoutCount = 0;
+
+    // remove timeout styling
+    if (this._container) {
+      removeClasses(this._container, "locate-timeout");
+    }
 
     // true if the user has panned the map after clicking the control
     this._userPanned = false;


### PR DESCRIPTION
### The Problem

The issue (#366) reports that timeout doesn't work in watch mode. After digging into the code, I found this is actually intentional behavior: when `watch: true`, timeout errors are silently ignored so the control keeps trying to get a location.

While this makes sense technically, it creates a **UX problem**: users just see an endlessly spinning icon with no indication that GPS acquisition is struggling or failing.

### The Solution

Rather than changing the core behavior (which could break existing apps), I've added feedback mechanisms:

**1. New `locationtimeout` event** for developers:
```js
map.on('locationtimeout', (e) => {
  console.log('Timeout #' + e.count);
  // Show custom notification, retry logic, etc.
});
```

**2. Visual feedback** for users: After 3 consecutive timeouts (~15 seconds with typical settings), the spinner turns orange to signal *"this is taking longer than usual"*.

   https://github.com/user-attachments/assets/1d964e9c-0a3a-4114-964e-1051395216ce

### Demo

For testing and showcasing the new feature I've created an extra demo page** (`demo/test-timeout.html`) that simulates poor GPS signal. You can check it out here: https://kristjanesperanto.github.io/leaflet-locatecontrol/demo/test-timeout.html.

### Why This Approach?

- Non-breaking - existing basic behavior unchanged
- Users get visual feedback automatically (better default UX)
- Developers can hook into the event for custom UX

The control still keeps trying in watch mode (as designed), but now both users and developers know what's happening.

---

I also updated a few URLs in the README.