### PR TITLE
refactor(setView): improve code consistency and readability

### DIFF
--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -308,6 +308,17 @@ describe("LocateControl", () => {
     });
   });
 
+  describe("setView", () => {
+    it("should zoom to initialZoomLevel when justClicked", () => {
+      const control = new LocateControl({ initialZoomLevel: 15 });
+      map.addControl(control);
+      control._event = { latlng: { lat: 51.5, lng: -0.09 }, accuracy: 100 };
+      control._justClicked = true;
+      control.setView();
+      assert.strictEqual(map.getZoom(), 15);
+    });
+  });
+
   describe("Popup Binding", () => {
     it("should bind popup to marker when showPopup is true", () => {
       const control = new LocateControl({ showPopup: true });

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -625,26 +625,29 @@ const LocateControl = Control.extend({
     if (this._isOutsideMapBounds()) {
       this._event = undefined; // clear the current location so we can get back into the bounds
       this.options.onLocationOutsideMapBounds(this);
+      return;
+    }
+
+    const latlng = this._event.latlng;
+
+    if (this._justClicked && this.options.initialZoomLevel !== false) {
+      const f = this.options.flyTo ? this._map.flyTo : this._map.setView;
+      f.bind(this._map)(latlng, this.options.initialZoomLevel);
+    } else if (this._shouldKeepCurrentZoom()) {
+      const f = this.options.flyTo ? this._map.flyTo : this._map.panTo;
+      f.bind(this._map)(latlng);
     } else {
-      if (this._justClicked && this.options.initialZoomLevel !== false) {
-        let f = this.options.flyTo ? this._map.flyTo : this._map.setView;
-        f.bind(this._map)([this._event.latitude, this._event.longitude], this.options.initialZoomLevel);
-      } else if (this._shouldKeepCurrentZoom()) {
-        let f = this.options.flyTo ? this._map.flyTo : this._map.panTo;
-        f.bind(this._map)([this._event.latitude, this._event.longitude]);
-      } else {
-        let f = this.options.flyTo ? this._map.flyToBounds : this._map.fitBounds;
-        // Ignore zoom events while setting the viewport as these would stop following
-        this._ignoreEvent = true;
-        f.bind(this._map)(this.options.getLocationBounds(this._event), {
-          padding: this.options.circlePadding,
-          maxZoom: this.options.initialZoomLevel || this.options.locateOptions.maxZoom
-        });
-        requestAnimationFrame(() => {
-          // Wait until after the next animFrame because the flyTo can be async
-          this._ignoreEvent = false;
-        });
-      }
+      const f = this.options.flyTo ? this._map.flyToBounds : this._map.fitBounds;
+      // Ignore zoom events while setting the viewport as these would stop following
+      this._ignoreEvent = true;
+      f.bind(this._map)(this.options.getLocationBounds(this._event), {
+        padding: this.options.circlePadding,
+        maxZoom: this.options.initialZoomLevel || this.options.locateOptions.maxZoom
+      });
+      requestAnimationFrame(() => {
+        // Wait until after the next animFrame because the flyTo can be async
+        this._ignoreEvent = false;
+      });
     }
   },
 


### PR DESCRIPTION
- Use `this._event.latlng` instead of `[this._event.latitude, this._event.longitude]` for consistency with the rest of the codebase
- Add early return after `onLocationOutsideMapBounds` to reduce nesting
- Change `let` to `const` where variables are not reassigned
- Add test for `initialZoomLevel` behavior

There are no functional changes.