### PR TITLE
fix: strings.text styling and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `icon` | `string`  | The CSS class for the icon. | `leaflet-control-locate-location-arrow` |
 | `iconLoading` | `string`  | The CSS class for the icon while loading. | `leaflet-control-locate-spinner` |
 | `iconElementTag` | `string`  | The element to be created for icons. | `span` |
+| `textElementTag` | `string`  | The element to be created for the text. | `small` |
 | `circlePadding` | `array`  | Padding around the accuracy circle. | `[0, 0]` |
 | `createButtonCallback` | `function`  | This callback can be used in case you would like to override button creation behavior. | see code |
 | `getLocationBounds` | `function`  | This callback can be used to override the viewport tracking behavior. | see code |
@@ -137,6 +138,19 @@ var lc = L.control
     position: "topright",
     strings: {
       title: "Show me where I am, yo!"
+    }
+  })
+  .addTo(map);
+```
+
+To add text next to the location icon:
+
+```js
+var lc = L.control
+  .locate({
+    strings: {
+      title: "Show me where I am, yo!",
+      text: "Locate me"
     }
   })
   .addTo(map);

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Possible options are listed in the following table. More details are [in the cod
 For example, to customize the position and the title, you could write
 
 ```js
-var lc = L.control
+let lc = L.control
   .locate({
     position: "topright",
     strings: {
@@ -146,7 +146,7 @@ var lc = L.control
 To add text next to the location icon:
 
 ```js
-var lc = L.control
+let lc = L.control
   .locate({
     strings: {
       title: "Show me where I am, yo!",
@@ -182,7 +182,7 @@ You can call `start()` or `stop()` on the locate control object to set the locat
 
 ```js
 // create control and add to map
-var lc = L.control.locate().addTo(map);
+let lc = L.control.locate().addTo(map);
 
 // request location update and set location
 lc.start();
@@ -218,7 +218,7 @@ L.Control.MyLocate = L.Control.Locate.extend({
   }
 });
 
-var lc = new L.Control.MyLocate();
+let lc = new L.Control.MyLocate();
 ```
 
 ### FAQ

--- a/demo/esm/script.js
+++ b/demo/esm/script.js
@@ -41,8 +41,18 @@ let map = new Map("map", {
   zoomControl: true
 });
 
+// Default control (top left)
 new LocateControl({
   strings: {
     title: "Show me where I am, yo!"
+  }
+}).addTo(map);
+
+// Control with text (bottom left)
+new LocateControl({
+  position: "bottomleft",
+  strings: {
+    title: "Show me where I am, yo!",
+    text: "Locate me"
   }
 }).addTo(map);

--- a/src/L.Control.Locate.css
+++ b/src/L.Control.Locate.css
@@ -39,17 +39,23 @@
   }
 }
 
-.leaflet-touch .leaflet-bar .leaflet-locate-text-active {
-  width: 100%;
+.leaflet-bar .leaflet-locate-text-active {
+  width: auto;
   max-width: 200px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   padding: 0 10px;
+  display: flex;
+  align-items: center;
 
   .leaflet-locate-icon {
     padding: 0 5px 0 0;
   }
+}
+
+.leaflet-touch .leaflet-bar .leaflet-locate-text-active {
+  width: 100%;
 }
 
 .leaflet-control-locate-location circle {

--- a/src/L.Control.Locate.d.ts
+++ b/src/L.Control.Locate.d.ts
@@ -5,6 +5,7 @@ export type ClickBehavior = "stop" | "setView";
 
 export interface StringsOptions {
   title?: string | undefined;
+  text?: string | undefined;
   metersUnit?: string | undefined;
   feetUnit?: string | undefined;
   popup?: string | undefined;


### PR DESCRIPTION
I reviewed issue #290 and looked into the `strings.text` feature. During testing, I noticed that the styling for this feature was broken.

### Changes

**Fix CSS styling:**
- Added base styling for `.leaflet-locate-text-active` that works on all devices
- Added flexbox layout for proper icon/text alignment
- Fixed missing `display: flex` and `align-items: center` properties

  **Before**
  <img width="105" height="43" alt="bildo" src="https://github.com/user-attachments/assets/19d1bd85-dc9e-45ae-bc2b-c1f3223836da" />

  **After**
  <img width="107" height="42" alt="bildo" src="https://github.com/user-attachments/assets/768afd31-787b-4f8a-bdfc-7bd3a2269c3b" />

**Improve documentation:**
- Added `strings.text` to TypeScript `StringsOptions` interface
- Added `textElementTag` option to README options table
- Added usage example demonstrating `strings.text`
- Use `let` instead of `var`

**Enhance demo:**
- Added second control with text to ESM demo to showcase the feature
- Shows both icon-only (default) and icon+text variants side by side

### Closes #290

The `strings.text` option is now properly documented and shown in the ESM demo.