### PR TITLE
feat: add locatelocationfound event

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,26 @@ You can keep the plugin active but stop following using `lc.stopFollowing()`.
 
 You can leverage the native Leaflet events `locationfound` and `locationerror` to handle when geolocation is successful or produces an error. You can find out more about these events in the [Leaflet documentation](https://leafletjs.com/examples/mobile/#geolocation).
 
-Additionally, the locate control fires `locateactivate` and `locatedeactivate` events on the map object when it is activated and deactivated, respectively.
+Additionally, the locate control fires the following events on the map object:
 
-The control also fires a `locationtimeout` event when geolocation timeouts occur in watch mode. This is useful for providing custom feedback to users when location acquisition takes longer than expected:
+| Event                 | Description                                                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `locateactivate`      | Fired when the control is activated                                                                             |
+| `locatedeactivate`    | Fired when the control is deactivated                                                                           |
+| `locatelocationfound` | Fired when a location is found (includes `latlng`, `accuracy`, `bounds`, `control`, and other geolocation data) |
+| `locationtimeout`     | Fired when geolocation timeouts occur in watch mode                                                             |
+
+The `locatelocationfound` event is particularly useful when you need to react to location updates with access to the control instance. For example, to get the location once and then stop:
+
+```js
+map.on("locatelocationfound", function (e) {
+  console.log("Location found:", e.latlng);
+  console.log("Accuracy:", e.accuracy, "meters");
+  e.control.stop(); // Stop after first location ("one-shot" behavior)
+});
+```
+
+The `locationtimeout` event is useful when geolocation timeouts occur in watch mode. This is useful for providing custom feedback to users when location acquisition takes longer than expected:
 
 ```js
 map.on("locationtimeout", function (e) {

--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -291,6 +291,61 @@ describe("LocateControl", () => {
     });
   });
 
+  describe("Events", () => {
+    it("should fire locatelocationfound event when location is found", () => {
+      const control = new LocateControl({ setView: false });
+      map.addControl(control);
+
+      let eventFired = false;
+      let eventData = null;
+
+      map.on("locatelocationfound", (e) => {
+        eventFired = true;
+        eventData = e;
+      });
+
+      // Simulate the control being active
+      control._active = true;
+
+      // Simulate a location found event
+      const locationEvent = {
+        latlng: { lat: 51.5, lng: -0.09 },
+        accuracy: 100,
+        altitude: 50,
+        altitudeAccuracy: 10,
+        heading: 90,
+        speed: 5,
+        timestamp: Date.now(),
+        bounds: null
+      };
+
+      control._onLocationFound(locationEvent);
+
+      assert.ok(eventFired, "Event should be fired");
+      assert.deepStrictEqual(eventData.latlng, locationEvent.latlng);
+      assert.strictEqual(eventData.accuracy, 100);
+      assert.strictEqual(eventData.control, control);
+    });
+
+    it("should allow stopping the control from the event handler (oneshot)", () => {
+      const control = new LocateControl({ setView: false });
+      map.addControl(control);
+
+      map.on("locatelocationfound", (e) => {
+        e.control.stop();
+      });
+
+      control._active = true;
+      control._onLocationFound({
+        latlng: { lat: 51.5, lng: -0.09 },
+        accuracy: 100,
+        bounds: null
+      });
+
+      assert.strictEqual(control._active, false, "Control should be stopped");
+    });
+  });
+
   describe("Control Lifecycle", () => {
     it("should add layer to map when added", () => {
       const control = new LocateControl();

--- a/src/L.Control.Locate.d.ts
+++ b/src/L.Control.Locate.d.ts
@@ -1,6 +1,16 @@
 import { Control, Layer, Map, ControlOptions, PathOptions, MarkerOptions, LocationEvent, LatLngBounds, LocateOptions as LeafletLocateOptions } from "leaflet";
 
 export type SetView = false | "once" | "always" | "untilPan" | "untilPanOrZoom";
+
+/**
+ * Event fired when a location is found by the locate control.
+ * Extends Leaflet's LocationEvent with a reference to the control instance.
+ */
+export interface LocateLocationFoundEvent extends LocationEvent {
+  /** Reference to the locate control instance */
+  control: LocateControl;
+}
+
 export type ClickBehavior = "stop" | "setView";
 
 export interface StringsOptions {

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -882,6 +882,12 @@ const LocateControl = Control.extend({
     this._drawMarker();
     this._updateContainerStyle();
 
+    // Fire event with location data and control reference
+    this._map.fire("locatelocationfound", {
+      ...e,
+      control: this
+    });
+
     switch (this.options.setView) {
       case "once":
         if (this._justClicked) {


### PR DESCRIPTION
I looked at PR #343, which has been open since 2023. The implementation had issues, but the use case is valid. This PR here takes a different approach - using an event instead of a callback option - which is more flexible and consistent with Leaflet's patterns.

## Why is this useful?

Some practical scenarios I can imagine would need access to the control when location is found:

- **One-shot location** - Get user location once, then stop (e.g., "show nearby restaurants")
- **Custom zoom** - Fit bounds to include user + target marker (urb4nc4rl's use case from #343)
- **Geofencing** - Check if user is in delivery area
- **Analytics** - Track accuracy and behavior
- **Form autofill** - Reverse geocode address

## Why add it to the plugin?

**"Can't you just use `map.locate()` directly without the plugin?"**

Yes, but the plugin provides UI, marker rendering, accuracy circles, compass, zoom behavior, popups, error handling, and visual states. Most apps use the plugin for this functionality.

**"Then just listen to the native `locationfound` event?"**

You can:

```js
const lc = L.control.locate().addTo(map);
map.on('locationfound', (e) => {
  lc.stop();
});
```

But this requires keeping a separate control reference - extra boilerplate.

## What this PR does

Adds a `locatelocationfound` event with direct control access:

```js
map.on('locatelocationfound', (e) => {
  console.log(e.latlng, e.accuracy);
  e.control.stop(); // No separate reference needed
});
```

This matches the existing pattern - `locateactivate`, `locatedeactivate`, and `locationtimeout` already pass the control instance.

**Changes:**
- New event with TypeScript types
- Tests added
- Docs updated
