### PR TITLE
feat: add lat, lnga and altitude to popup template

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `onLocationOutsideMapBounds` | `function`  | Called when the user's location is outside the bounds set on the map. Called repeatedly when the user's location changes. | see code |
 | `showPopup` | `boolean`  | Display a pop-up when the user click on the inner marker. | `true` |
 | `strings` | `object`  | Strings used in the control. Options are `title`, `text`, `metersUnit`, `feetUnit`, `popup` and `outsideMapBoundsMsg` | see code |
-| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}` and `{unit}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit}` and expected to return a string. | see code |
+| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}`, `{unit}`, `{lat}`, `{lng}`, and `{altitude}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit, lat, lng, altitude}` and expected to return a string. | see code |
 | `locateOptions` | [`Locate options`](https://leafletjs.com/reference.html#locate-options)  | The default options passed to leaflets locate method. | see code |
 <!-- prettier-ignore-end -->
 

--- a/demo/esm/index.html
+++ b/demo/esm/index.html
@@ -22,7 +22,7 @@
   </head>
   <body>
     <button id="dark-mode-toggle" title="Demo: Toggle Dark Mode to see control color changes">🌓</button>
-    <div id="map" style="width: 100%; height: 100vh"></div>
+    <div id="map" style="width: 100%; height: 100%"></div>
     <div id="forkmeongithub"><a href="https://github.com/domoritz/leaflet-locatecontrol" target="_blank">Fork me on GitHub</a></div>
   </body>
 </html>

--- a/demo/esm/script.js
+++ b/demo/esm/script.js
@@ -54,6 +54,6 @@ new LocateControl({
   strings: {
     title: "Show me where I am, yo!",
     text: "Locate me",
-    popup: "Lat: {lat}<br>Lng: {lng}<br>Alt: {altitude}m<br>Accuracy: ±{distance} {unit}"
+    popup: "Lat: {lat}<br>Lng: {lng}<br>Alt: {altitude} {unit}<br>Accuracy: ±{distance} {unit}"
   }
 }).addTo(map);

--- a/demo/esm/script.js
+++ b/demo/esm/script.js
@@ -48,11 +48,12 @@ new LocateControl({
   }
 }).addTo(map);
 
-// Control with text (bottom left)
+// Control with text (bottom left) - demonstrates lat/lng/altitude in popup
 new LocateControl({
   position: "bottomleft",
   strings: {
     title: "Show me where I am, yo!",
-    text: "Locate me"
+    text: "Locate me",
+    popup: "Lat: {lat}<br>Lng: {lng}<br>Alt: {altitude}m<br>Accuracy: ±{distance} {unit}"
   }
 }).addTo(map);

--- a/demo/style.css
+++ b/demo/style.css
@@ -40,6 +40,7 @@ html,
 body {
   padding: 0;
   margin: 0;
+  height: 100%;
   background-color: #fff;
   color: #000;
   transition:

--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -499,6 +499,74 @@ describe("LocateControl", () => {
       assert.ok(control._marker);
       assert.ok(control._marker.getPopup());
     });
+
+    it("should include lat, lng, and altitude in popup text", () => {
+      const control = new LocateControl({
+        showPopup: true,
+        strings: {
+          popup: "{lat} {lng} {altitude} {distance} {unit}"
+        }
+      });
+      map.addControl(control);
+
+      control._event = {
+        latlng: { lat: 51.505, lng: -0.09 },
+        accuracy: 100,
+        altitude: 42
+      };
+      control._drawMarker();
+
+      const popupContent = control._marker.getPopup().getContent();
+      assert.ok(popupContent.includes("51.505"), "popup should contain lat");
+      assert.ok(popupContent.includes("-0.09"), "popup should contain lng");
+      assert.ok(popupContent.includes("42"), "popup should contain altitude");
+    });
+
+    it("should show N/A for altitude when not available", () => {
+      const control = new LocateControl({
+        showPopup: true,
+        strings: {
+          popup: "alt:{altitude}"
+        }
+      });
+      map.addControl(control);
+
+      control._event = {
+        latlng: { lat: 51.505, lng: -0.09 },
+        accuracy: 100
+      };
+      control._drawMarker();
+
+      const popupContent = control._marker.getPopup().getContent();
+      assert.ok(popupContent.includes("N/A"), "popup should show N/A when altitude is not available");
+    });
+
+    it("should pass all template data to popup function", () => {
+      let receivedData;
+      const control = new LocateControl({
+        showPopup: true,
+        strings: {
+          popup: (data) => {
+            receivedData = data;
+            return "test";
+          }
+        }
+      });
+      map.addControl(control);
+
+      control._event = {
+        latlng: { lat: 51.505, lng: -0.09 },
+        accuracy: 200,
+        altitude: 15
+      };
+      control._drawMarker();
+
+      assert.strictEqual(receivedData.lat, 51.505);
+      assert.strictEqual(receivedData.lng, -0.09);
+      assert.strictEqual(receivedData.altitude, 15);
+      assert.ok(receivedData.distance);
+      assert.ok(receivedData.unit);
+    });
   });
 });
 

--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -512,14 +512,14 @@ describe("LocateControl", () => {
       control._event = {
         latlng: { lat: 51.505, lng: -0.09 },
         accuracy: 100,
-        altitude: 42
+        altitude: 42.7
       };
       control._drawMarker();
 
       const popupContent = control._marker.getPopup().getContent();
-      assert.ok(popupContent.includes("51.505"), "popup should contain lat");
-      assert.ok(popupContent.includes("-0.09"), "popup should contain lng");
-      assert.ok(popupContent.includes("42"), "popup should contain altitude");
+      assert.ok(popupContent.includes("51.505000"), "popup should contain formatted lat");
+      assert.ok(popupContent.includes("-0.090000"), "popup should contain formatted lng");
+      assert.ok(popupContent.includes("42.7"), "popup should contain altitude");
     });
 
     it("should show N/A for altitude when not available", () => {
@@ -561,9 +561,9 @@ describe("LocateControl", () => {
       };
       control._drawMarker();
 
-      assert.strictEqual(receivedData.lat, 51.505);
-      assert.strictEqual(receivedData.lng, -0.09);
-      assert.strictEqual(receivedData.altitude, 15);
+      assert.strictEqual(receivedData.lat, "51.505000");
+      assert.strictEqual(receivedData.lng, "-0.090000");
+      assert.strictEqual(receivedData.altitude, "15.0");
       assert.ok(receivedData.distance);
       assert.ok(receivedData.unit);
     });

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -745,7 +745,7 @@ const LocateControl = Control.extend({
   },
 
   /**
-   * Bind popup with distance information to marker and compass.
+   * Bind popup with location information to marker and compass.
    * @param {L.LatLng} latlng - The location to bind the popup to.
    * @param {number} accuracy - The accuracy radius in meters.
    */
@@ -766,12 +766,21 @@ const LocateControl = Control.extend({
       unit = this.options.strings.feetUnit;
     }
 
+    // Collect template data
+    const data = {
+      distance,
+      unit,
+      lat: latlng.lat,
+      lng: latlng.lng,
+      altitude: this._event?.altitude ?? "N/A"
+    };
+
     // Generate popup text
     let popupText;
     if (typeof t === "string") {
-      popupText = LeafletUtil.template(t, { distance, unit });
+      popupText = LeafletUtil.template(t, data);
     } else if (typeof t === "function") {
-      popupText = t({ distance, unit });
+      popupText = t(data);
     } else {
       popupText = t;
     }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -758,21 +758,24 @@ const LocateControl = Control.extend({
     // Format distance for display
     let distance;
     let unit;
+    let altitude;
     if (this.options.metric) {
       distance = accuracy.toFixed(0);
       unit = this.options.strings.metersUnit;
+      altitude = this._event?.altitude != null ? this._event.altitude.toFixed(1) : "N/A";
     } else {
       distance = (accuracy * METERS_TO_FEET).toFixed(0);
       unit = this.options.strings.feetUnit;
+      altitude = this._event?.altitude != null ? (this._event.altitude * METERS_TO_FEET).toFixed(1) : "N/A";
     }
 
     // Collect template data
     const data = {
       distance,
       unit,
-      lat: latlng.lat,
-      lng: latlng.lng,
-      altitude: this._event?.altitude ?? "N/A"
+      lat: latlng.lat.toFixed(6),
+      lng: latlng.lng.toFixed(6),
+      altitude
     };
 
     // Generate popup text


### PR DESCRIPTION
Expands the popup template context to include latitude, longitude, and altitude values. Users can now customize the popup with these placeholders: {lat}, {lng}, {altitude}.

The change is fully backward compatible - existing popup templates continue to work unchanged.

Updated ESM demo (the second control) to showcase the new template variables.

<img width="1171" height="638" alt="screenshot" src="https://github.com/user-attachments/assets/bf406cbd-2d16-4ea0-97c2-3c7b3d36a6b2" />




Closes #335

In addition, I fixed a minor viewport issue with mobile browsers in the ESM demo.

----

Live demo: https://kristjanesperanto.github.io/leaflet-locatecontrol/demo/esm/ (use the control at the bottom left).