### PR TITLE
refactor: improve compass activation/deactivation and error handling

### DIFF
--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
 import assert from "node:assert";
 import "./setup.js";
 import { Map, LayerGroup } from "leaflet";
@@ -491,6 +491,154 @@ describe("LocateControl", () => {
         // Restore original method
         map.flyTo = originalFlyTo;
       }
+    });
+  });
+
+  describe("Compass Activation", () => {
+    let originalOnDeviceOrientation;
+    let originalOnDeviceOrientationAbsolute;
+    let originalRequestPermission;
+
+    beforeEach(() => {
+      originalOnDeviceOrientation = window.ondeviceorientation;
+      originalOnDeviceOrientationAbsolute = window.ondeviceorientationabsolute;
+      originalRequestPermission = DeviceOrientationEvent.requestPermission;
+
+      // Default: deviceorientation supported, no requestPermission
+      window.ondeviceorientation = null;
+      delete window.ondeviceorientationabsolute;
+      delete DeviceOrientationEvent.requestPermission;
+    });
+
+    afterEach(() => {
+      // Restore originals
+      if (originalOnDeviceOrientation !== undefined) {
+        window.ondeviceorientation = originalOnDeviceOrientation;
+      } else {
+        delete window.ondeviceorientation;
+      }
+      if (originalOnDeviceOrientationAbsolute !== undefined) {
+        window.ondeviceorientationabsolute = originalOnDeviceOrientationAbsolute;
+      } else {
+        delete window.ondeviceorientationabsolute;
+      }
+      if (originalRequestPermission !== undefined) {
+        DeviceOrientationEvent.requestPermission = originalRequestPermission;
+      } else {
+        delete DeviceOrientationEvent.requestPermission;
+      }
+      mock.restoreAll();
+    });
+
+    it("should skip compass when showCompass is false", async () => {
+      const control = new LocateControl({ showCompass: false });
+      map.addControl(control);
+      const spy = mock.method(control, "_onDeviceOrientation");
+
+      await control._activateCompass();
+
+      // Dispatch orientation event — should not be received
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 90 }));
+      assert.strictEqual(spy.mock.callCount(), 0, "_onDeviceOrientation should not be called");
+    });
+
+    it("should skip compass when device has no orientation support", async () => {
+      delete window.ondeviceorientation;
+      delete window.ondeviceorientationabsolute;
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      const spy = mock.method(control, "_onDeviceOrientation");
+
+      await control._activateCompass();
+
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 90 }));
+      assert.strictEqual(spy.mock.callCount(), 0, "_onDeviceOrientation should not be called");
+    });
+
+    it("should bind deviceorientation event when supported", async () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      // Verify the handler is bound by dispatching an event
+      const event = new DeviceOrientationEvent("deviceorientation", { alpha: 90, absolute: true });
+      window.dispatchEvent(event);
+      assert.strictEqual(control._compassHeading, 270, "Should process orientation event (360 - 90)");
+    });
+
+    it("should prefer deviceorientationabsolute when available", async () => {
+      window.ondeviceorientationabsolute = null;
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      // deviceorientation should NOT trigger the handler
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 45, absolute: true }));
+      assert.strictEqual(control._compassHeading, null, "Should not react to deviceorientation");
+
+      // deviceorientationabsolute SHOULD trigger the handler
+      const event = new DeviceOrientationEvent("deviceorientationabsolute", { alpha: 45, absolute: true });
+      window.dispatchEvent(event);
+      assert.strictEqual(control._compassHeading, 315, "Should process absolute orientation event");
+    });
+
+    it("should bind compass when requestPermission grants access", async () => {
+      DeviceOrientationEvent.requestPermission = async () => "granted";
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      const event = new DeviceOrientationEvent("deviceorientation", { alpha: 180, absolute: true });
+      window.dispatchEvent(event);
+      assert.strictEqual(control._compassHeading, 180, "Should process orientation after granted permission");
+    });
+
+    it("should not bind compass when requestPermission denies access", async () => {
+      DeviceOrientationEvent.requestPermission = async () => "denied";
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      const spy = mock.method(control, "_onDeviceOrientation");
+
+      await control._activateCompass();
+
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 90 }));
+      assert.strictEqual(spy.mock.callCount(), 0, "_onDeviceOrientation should not be called when denied");
+    });
+
+    it("should handle requestPermission rejection gracefully", async () => {
+      DeviceOrientationEvent.requestPermission = async () => {
+        throw new Error("NotAllowedError");
+      };
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      const spy = mock.method(control, "_onDeviceOrientation");
+
+      // Should not throw
+      await control._activateCompass();
+
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 90 }));
+      assert.strictEqual(spy.mock.callCount(), 0, "_onDeviceOrientation should not be called after rejection");
+    });
+
+    it("should call _activateCompass from _activate", () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      const spy = mock.method(control, "_activateCompass", () => {});
+
+      control._activate();
+
+      assert.strictEqual(spy.mock.callCount(), 1, "_activateCompass should be called once");
     });
   });
 

--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -642,6 +642,101 @@ describe("LocateControl", () => {
     });
   });
 
+  describe("Compass Deactivation", () => {
+    let originalOnDeviceOrientation;
+    let originalOnDeviceOrientationAbsolute;
+
+    beforeEach(() => {
+      originalOnDeviceOrientation = window.ondeviceorientation;
+      originalOnDeviceOrientationAbsolute = window.ondeviceorientationabsolute;
+
+      window.ondeviceorientation = null;
+      delete window.ondeviceorientationabsolute;
+      delete DeviceOrientationEvent.requestPermission;
+    });
+
+    afterEach(() => {
+      if (originalOnDeviceOrientation !== undefined) {
+        window.ondeviceorientation = originalOnDeviceOrientation;
+      } else {
+        delete window.ondeviceorientation;
+      }
+      if (originalOnDeviceOrientationAbsolute !== undefined) {
+        window.ondeviceorientationabsolute = originalOnDeviceOrientationAbsolute;
+      } else {
+        delete window.ondeviceorientationabsolute;
+      }
+      mock.restoreAll();
+    });
+
+    it("should stop receiving orientation events after deactivate", async () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      // Sanity check: events are received while active
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 90, absolute: true }));
+      assert.strictEqual(control._compassHeading, 270, "Should receive events before deactivate");
+
+      control._deactivate();
+
+      // Events after deactivate should not update compassHeading
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 45, absolute: true }));
+      assert.strictEqual(control._compassHeading, null, "Should not receive events after deactivate");
+    });
+
+    it("should reset _compassHeading to null on deactivate", async () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientation", { alpha: 90, absolute: true }));
+      assert.strictEqual(control._compassHeading, 270, "Should have a heading before deactivate");
+
+      control._deactivate();
+
+      assert.strictEqual(control._compassHeading, null, "_compassHeading should be null after deactivate");
+    });
+
+    it("should remove deviceorientationabsolute listener when that was bound", async () => {
+      window.ondeviceorientationabsolute = null;
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      // Sanity check: absolute events are received
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientationabsolute", { alpha: 90, absolute: true }));
+      assert.strictEqual(control._compassHeading, 270, "Should receive absolute events before deactivate");
+
+      control._deactivate();
+
+      window.dispatchEvent(new DeviceOrientationEvent("deviceorientationabsolute", { alpha: 45, absolute: true }));
+      assert.strictEqual(control._compassHeading, null, "Should not receive absolute events after deactivate");
+    });
+
+    it("should deactivate cleanly when compass listener was never bound", async () => {
+      // Simulate no orientation support — _activateCompass binds nothing
+      delete window.ondeviceorientation;
+      delete window.ondeviceorientationabsolute;
+
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      await control._activateCompass();
+
+      // Should not throw
+      assert.doesNotThrow(() => control._deactivate());
+    });
+  });
+
   describe("Popup Binding", () => {
     it("should bind popup to marker when showPopup is true", () => {
       const control = new LocateControl({ showPopup: true });

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -620,11 +620,22 @@ const LocateControl = Control.extend({
     this._map.off("dragstart", this._onDrag, this);
     this._map.off("zoomstart", this._onZoom, this);
     this._map.off("zoomend", this._onZoomEnd, this);
-    if (this._compassEventName) {
-      this._compassHeading = null;
-      DomEvent.off(window, this._compassEventName, this._onDeviceOrientation, this);
-      this._compassEventName = null;
+
+    this._deactivateCompass();
+  },
+
+  /**
+   * Remove compass event listener and reset compass heading state.
+   * Symmetric counterpart to _activateCompass().
+   */
+  _deactivateCompass() {
+    if (!this._compassEventName) {
+      return;
     }
+
+    this._compassHeading = null;
+    DomEvent.off(window, this._compassEventName, this._onDeviceOrientation, this);
+    this._compassEventName = null;
   },
 
   /**

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -592,6 +592,7 @@ const LocateControl = Control.extend({
       }
     }
 
+    this._compassEventName = eventName;
     DomEvent.on(window, eventName, this._onDeviceOrientation, this);
   },
 
@@ -619,13 +620,10 @@ const LocateControl = Control.extend({
     this._map.off("dragstart", this._onDrag, this);
     this._map.off("zoomstart", this._onZoom, this);
     this._map.off("zoomend", this._onZoomEnd, this);
-    if (this.options.showCompass) {
+    if (this._compassEventName) {
       this._compassHeading = null;
-      if ("ondeviceorientationabsolute" in window) {
-        DomEvent.off(window, "deviceorientationabsolute", this._onDeviceOrientation, this);
-      } else if ("ondeviceorientation" in window) {
-        DomEvent.off(window, "deviceorientation", this._onDeviceOrientation, this);
-      }
+      DomEvent.off(window, this._compassEventName, this._onDeviceOrientation, this);
+      this._compassEventName = null;
     }
   },
 

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -543,7 +543,7 @@ const LocateControl = Control.extend({
    * It should set the this._active to true and do nothing if
    * this._active is true.
    */
-  _activate() {
+  async _activate() {
     if (this._active || !this._map) {
       return;
     }
@@ -566,11 +566,16 @@ const LocateControl = Control.extend({
           DomEvent.on(window, oriAbs ? "deviceorientationabsolute" : "deviceorientation", _this._onDeviceOrientation, _this);
         };
         if (DeviceOrientationEvent && typeof DeviceOrientationEvent.requestPermission === "function") {
-          DeviceOrientationEvent.requestPermission().then(function (permissionState) {
+          try {
+            const permissionState = await DeviceOrientationEvent.requestPermission();
             if (permissionState === "granted") {
               deviceorientation();
             }
-          });
+          } catch (err) {
+            // Permission denied or not supported (e.g. iOS Chrome / WKWebView)
+            // Compass will not be shown but geolocation continues normally
+            console.warn("DeviceOrientation permission denied or unavailable:", err);
+          }
         } else {
           deviceorientation();
         }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -543,7 +543,7 @@ const LocateControl = Control.extend({
    * It should set the this._active to true and do nothing if
    * this._active is true.
    */
-  async _activate() {
+  _activate() {
     if (this._active || !this._map) {
       return;
     }
@@ -558,29 +558,41 @@ const LocateControl = Control.extend({
     this._map.on("dragstart", this._onDrag, this);
     this._map.on("zoomstart", this._onZoom, this);
     this._map.on("zoomend", this._onZoomEnd, this);
-    if (this.options.showCompass) {
-      const oriAbs = "ondeviceorientationabsolute" in window;
-      if (oriAbs || "ondeviceorientation" in window) {
-        const _this = this;
-        const deviceorientation = function () {
-          DomEvent.on(window, oriAbs ? "deviceorientationabsolute" : "deviceorientation", _this._onDeviceOrientation, _this);
-        };
-        if (DeviceOrientationEvent && typeof DeviceOrientationEvent.requestPermission === "function") {
-          try {
-            const permissionState = await DeviceOrientationEvent.requestPermission();
-            if (permissionState === "granted") {
-              deviceorientation();
-            }
-          } catch (err) {
-            // Permission denied or not supported (e.g. iOS Chrome / WKWebView)
-            // Compass will not be shown but geolocation continues normally
-            console.warn("DeviceOrientation permission denied or unavailable:", err);
-          }
-        } else {
-          deviceorientation();
+
+    this._activateCompass();
+  },
+
+  /**
+   * Request DeviceOrientation permission (if needed) and bind compass events.
+   * Fails gracefully — geolocation continues without compass.
+   */
+  async _activateCompass() {
+    if (!this.options.showCompass) {
+      return;
+    }
+
+    const oriAbs = "ondeviceorientationabsolute" in window;
+    if (!oriAbs && !("ondeviceorientation" in window)) {
+      return;
+    }
+
+    const eventName = oriAbs ? "deviceorientationabsolute" : "deviceorientation";
+
+    if (DeviceOrientationEvent && typeof DeviceOrientationEvent.requestPermission === "function") {
+      try {
+        const permissionState = await DeviceOrientationEvent.requestPermission();
+        if (permissionState !== "granted") {
+          return;
         }
+      } catch (err) {
+        // Permission denied or not supported (e.g. iOS Chrome / WKWebView)
+        // Compass will not be shown but geolocation continues normally
+        console.warn("DeviceOrientation permission denied or unavailable:", err);
+        return;
       }
     }
+
+    DomEvent.on(window, eventName, this._onDeviceOrientation, this);
   },
 
   /**


### PR DESCRIPTION
On iOS Chrome and other WKWebView-based browsers, `DeviceOrientationEvent.requestPermission()` can reject, causing an unhandled promise rejection in the console. This PR adds proper error handling and refactors the compass logic into dedicated methods.

Note: The underlying geolocation issue on iOS Chrome (#334) is a platform limitation that cannot be fixed in JavaScript. It may no longer occur on newer iOS versions — no new reports have been filed since 2023.

## Changes

### Error handling

- Wrap `DeviceOrientationEvent.requestPermission()` in `try/catch` so permission errors are caught and logged as a warning instead of producing unhandled rejections.

### Refactoring

- Extract `_activateCompass()` — compass setup (feature detection, permission request, event binding) in its own `async` method. Removes `const _this = this`, nested function declaration, and deep nesting.
- Extract `_deactivateCompass()` — symmetric counterpart for cleanup.
- Store bound event name in `_compassEventName` instead of re-running feature detection in `_deactivate()`.

### Tests

- 12 new tests covering compass activation and deactivation (permission granted/denied/rejected, feature detection, event binding/unbinding, cleanup).

## Breaking changes

None.
