### PR TITLE
refactor: replace Leaflet DOM helpers with native equivalents

### DIFF
--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -363,6 +363,62 @@ describe("LocateControl", () => {
     });
   });
 
+  describe("CSS state", () => {
+    it("should remove state classes when stopped", () => {
+      const control = new LocateControl();
+      map.addControl(control);
+      control._container.classList.add("requesting", "active", "following");
+      control.stop();
+      assert.ok(!control._container.classList.contains("requesting"));
+      assert.ok(!control._container.classList.contains("active"));
+      assert.ok(!control._container.classList.contains("following"));
+    });
+
+    it("should set requesting class when active without location", () => {
+      const control = new LocateControl();
+      map.addControl(control);
+      control._active = true;
+      control._event = undefined;
+      control._updateContainerStyle();
+      assert.ok(control._container.classList.contains("requesting"));
+      assert.ok(!control._container.classList.contains("active"));
+      assert.ok(!control._container.classList.contains("following"));
+    });
+
+    it("should set active class when active with location but not following", () => {
+      const control = new LocateControl({ setView: false });
+      map.addControl(control);
+      control._active = true;
+      control._event = { latlng: { lat: 51.5, lng: -0.09 }, accuracy: 50 };
+      control._updateContainerStyle();
+      assert.ok(control._container.classList.contains("active"));
+      assert.ok(!control._container.classList.contains("requesting"));
+      assert.ok(!control._container.classList.contains("following"));
+    });
+
+    it("should set following class when following", () => {
+      const control = new LocateControl({ setView: "always" });
+      map.addControl(control);
+      control._active = true;
+      control._event = { latlng: { lat: 51.5, lng: -0.09 }, accuracy: 50 };
+      control._updateContainerStyle();
+      assert.ok(control._container.classList.contains("active"));
+      assert.ok(control._container.classList.contains("following"));
+      assert.ok(!control._container.classList.contains("requesting"));
+    });
+
+    it("should restore default icon class when stopped", () => {
+      const control = new LocateControl();
+      map.addControl(control);
+      // Simulate loading state
+      control._icon.classList.remove(control.options.icon);
+      control._icon.classList.add(control.options.iconLoading);
+      control.stop();
+      assert.ok(control._icon.classList.contains(control.options.icon));
+      assert.ok(!control._icon.classList.contains(control.options.iconLoading));
+    });
+  });
+
   describe("setView", () => {
     it("should zoom to initialZoomLevel when justClicked", () => {
       const control = new LocateControl({ initialZoomLevel: 15 });

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -5,7 +5,7 @@ This file is part of the leaflet locate control. It is licensed under the MIT li
 You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
 */
 
-import { Control, Marker, DomUtil, setOptions, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
+import { Control, Marker, setOptions, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
 
 const METERS_TO_FEET = 3.2808399;
 
@@ -29,6 +29,20 @@ function removeClasses(el, names) {
   names.split(" ").forEach((className) => {
     el.classList.remove(className);
   });
+}
+
+/**
+ * Create a DOM element with a class name and optionally append it to a parent.
+ * @param {string} tag - The element tag name.
+ * @param {string} [className] - Space-separated class names.
+ * @param {HTMLElement} [parent] - Optional parent to append the element to.
+ * @returns {HTMLElement}
+ */
+function createElement(tag, className, parent) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  parent?.append(el);
+  return el;
 }
 
 /**
@@ -320,17 +334,17 @@ const LocateControl = Control.extend({
      * This function should return an object with HtmlElement for the button (link property) and the icon (icon property).
      */
     createButtonCallback(container, options) {
-      const link = DomUtil.create("a", "leaflet-bar-part leaflet-bar-part-single", container);
+      const link = createElement("a", "leaflet-bar-part leaflet-bar-part-single", container);
       link.title = options.strings.title;
       link.href = "#";
       link.setAttribute("role", "button");
       link.setAttribute("aria-label", options.strings.title);
-      const icon = DomUtil.create(options.iconElementTag, options.icon, link);
+      const icon = createElement(options.iconElementTag, options.icon, link);
       // Add common class for all icons to enable color status changes
       icon.classList.add("leaflet-locate-icon");
 
       if (options.strings.text !== undefined) {
-        const text = DomUtil.create(options.textElementTag, "leaflet-locate-text", link);
+        const text = createElement(options.textElementTag, "leaflet-locate-text", link);
         text.textContent = options.strings.text;
         link.classList.add("leaflet-locate-text-active");
         link.parentNode.style.display = "flex";
@@ -393,7 +407,7 @@ const LocateControl = Control.extend({
    * Add control to map. Returns the container for the control.
    */
   onAdd(map) {
-    const container = DomUtil.create("div", "leaflet-control-locate leaflet-bar leaflet-control");
+    const container = createElement("div", "leaflet-control-locate leaflet-bar leaflet-control");
     this._container = container;
     this._map = map;
     this._layer = this.options.layer || new LayerGroup();

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -5,7 +5,7 @@ This file is part of the leaflet locate control. It is licensed under the MIT li
 You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
 */
 
-import { Control, Marker, DomUtil, setOptions, divIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
+import { Control, Marker, DomUtil, setOptions, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
 
 const METERS_TO_FEET = 3.2808399;
 
@@ -81,7 +81,7 @@ const LocationMarker = Marker.extend({
 
     const icon = this._getIconSVG(opt, style);
 
-    this._locationIcon = divIcon({
+    this._locationIcon = new DivIcon({
       className: icon.className,
       html: icon.svg,
       iconSize: [icon.w, icon.h]

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -1065,10 +1065,7 @@ const LocateControl = Control.extend({
    * Removes all classes from button.
    */
   _cleanClasses() {
-    DomUtil.removeClass(this._container, "requesting");
-    DomUtil.removeClass(this._container, "active");
-    DomUtil.removeClass(this._container, "following");
-
+    removeClasses(this._container, "requesting active following");
     removeClasses(this._icon, this.options.iconLoading);
     addClasses(this._icon, this.options.icon);
   },


### PR DESCRIPTION
Small refactor PR that swaps out a few Leaflet utility calls for their native browser equivalents. No behaviour changes. This is also a further step towards Leaflet 2 compatibility, as these helpers are removed in Leaflet 2.

- `DomUtil.removeClass` → `removeClasses()` (module-local helper that already existed in the file)
- `divIcon()` factory function → `new DivIcon()` constructor
- `DomUtil.create()` (×4) → a small `createElement()` helper wrapping `document.createElement`. `DomUtil` is no longer imported at all.

Also adds tests for the CSS state transitions (`requesting`, `active`, `following`) that were previously untested.