### PR TITLE
feat: add speed and heading to popup template data

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Possible options are listed in the following table. More details are [in the cod
 | `metric` | `boolean` | Use metric units. | `true` |
 | `onLocationOutsideMapBounds` | `function`  | Called when the user's location is outside the bounds set on the map. Called repeatedly when the user's location changes. | see code |
 | `showPopup` | `boolean`  | Display a pop-up when the user click on the inner marker. | `true` |
-| `strings` | `object`  | Strings used in the control. Options are `title`, `text`, `metersUnit`, `feetUnit`, `popup` and `outsideMapBoundsMsg` | see code |
-| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}`, `{unit}`, `{lat}`, `{lng}`, and `{altitude}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit, lat, lng, altitude}` and expected to return a string. | see code |
+| `strings` | `object`  | Strings used in the control. Options are `title`, `text`, `metersUnit`, `feetUnit`, `kmhUnit`, `mphUnit`, `popup` and `outsideMapBoundsMsg` | see code |
+| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}`, `{unit}`, `{lat}`, `{lng}`, `{altitude}`, `{speed}`, `{speedUnit}`, and `{heading}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit, lat, lng, altitude, speed, speedUnit, heading}` and expected to return a string. | see code |
 | `locateOptions` | [`Locate options`](https://leafletjs.com/reference.html#locate-options)  | The default options passed to leaflets locate method. | see code |
 <!-- prettier-ignore-end -->
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Possible options are listed in the following table. More details are [in the cod
 | `metric` | `boolean` | Use metric units. | `true` |
 | `onLocationOutsideMapBounds` | `function`  | Called when the user's location is outside the bounds set on the map. Called repeatedly when the user's location changes. | see code |
 | `showPopup` | `boolean`  | Display a pop-up when the user click on the inner marker. | `true` |
-| `strings` | `object`  | Strings used in the control. Options are `title`, `text`, `metersUnit`, `feetUnit`, `kmhUnit`, `mphUnit`, `popup` and `outsideMapBoundsMsg` | see code |
-| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}`, `{unit}`, `{lat}`, `{lng}`, `{altitude}`, `{speed}`, `{speedUnit}`, and `{heading}`. If this option is specified as function, it will be executed with a single parameter `{distance, unit, lat, lng, altitude, speed, speedUnit, heading}` and expected to return a string. | see code |
+| `strings` | `object`  | Strings used in the control. Options are `title`, `text`, `metersUnit`, `feetUnit`, `popup` and `outsideMapBoundsMsg` | see code |
+| `strings.popup` | `string` or `function`  | The string shown as popup. May contain the placeholders `{distance}`, `{unit}`, `{lat}`, `{lng}`, `{altitude}`, `{speed}` (in m/s), and `{heading}` (in degrees). If this option is specified as function, it will be executed with a single parameter `{distance, unit, lat, lng, altitude, speed, heading}` and expected to return a string. | see code |
 | `locateOptions` | [`Locate options`](https://leafletjs.com/reference.html#locate-options)  | The default options passed to leaflets locate method. | see code |
 <!-- prettier-ignore-end -->
 

--- a/demo/esm/script.js
+++ b/demo/esm/script.js
@@ -48,12 +48,12 @@ new LocateControl({
   }
 }).addTo(map);
 
-// Control with text (bottom left) - demonstrates lat/lng/altitude in popup
+// Control with text (bottom left) - demonstrates all popup fields incl. speed & heading
 new LocateControl({
   position: "bottomleft",
   strings: {
     title: "Show me where I am, yo!",
     text: "Locate me",
-    popup: "Lat: {lat}<br>Lng: {lng}<br>Alt: {altitude} {unit}<br>Accuracy: ±{distance} {unit}"
+    popup: "{lat}, {lng}<br>Accuracy: ±{distance} {unit}<br>Altitude: {altitude} {unit}<br>Speed: {speed} {speedUnit}<br>Heading: {heading}°"
   }
 }).addTo(map);

--- a/demo/esm/script.js
+++ b/demo/esm/script.js
@@ -54,6 +54,6 @@ new LocateControl({
   strings: {
     title: "Show me where I am, yo!",
     text: "Locate me",
-    popup: "{lat}, {lng}<br>Accuracy: ±{distance} {unit}<br>Altitude: {altitude} {unit}<br>Speed: {speed} {speedUnit}<br>Heading: {heading}°"
+    popup: "{lat}, {lng}<br>Accuracy: ±{distance} {unit}<br>Altitude: {altitude} {unit}<br>Speed: {speed} m/s<br>Heading: {heading}°"
   }
 }).addTo(map);

--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -856,7 +856,9 @@ describe("LocateControl", () => {
       control._event = {
         latlng: { lat: 51.505, lng: -0.09 },
         accuracy: 200,
-        altitude: 15
+        altitude: 15,
+        speed: 5.5,
+        heading: 270
       };
       control._drawMarker();
 
@@ -865,6 +867,74 @@ describe("LocateControl", () => {
       assert.strictEqual(receivedData.altitude, "15.0");
       assert.ok(receivedData.distance);
       assert.ok(receivedData.unit);
+      assert.strictEqual(receivedData.speed, "19.8", "speed should be converted to km/h");
+      assert.strictEqual(receivedData.speedUnit, "km/h");
+      assert.strictEqual(receivedData.heading, "270", "heading should be in degrees");
+    });
+
+    it("should include speed and heading in popup template", () => {
+      const control = new LocateControl({
+        showPopup: true,
+        strings: {
+          popup: "{speed} {speedUnit} heading {heading}°"
+        }
+      });
+      map.addControl(control);
+
+      control._event = {
+        latlng: { lat: 51.505, lng: -0.09 },
+        accuracy: 100,
+        speed: 10,
+        heading: 90
+      };
+      control._drawMarker();
+
+      const popupContent = control._marker.getPopup().getContent();
+      assert.ok(popupContent.includes("36.0"), "popup should contain speed in km/h");
+      assert.ok(popupContent.includes("km/h"), "popup should contain speed unit");
+      assert.ok(popupContent.includes("90"), "popup should contain heading");
+    });
+
+    it("should show N/A for speed and heading when not available", () => {
+      const control = new LocateControl({
+        showPopup: true,
+        strings: {
+          popup: "speed:{speed} heading:{heading}"
+        }
+      });
+      map.addControl(control);
+
+      control._event = {
+        latlng: { lat: 51.505, lng: -0.09 },
+        accuracy: 100
+      };
+      control._drawMarker();
+
+      const popupContent = control._marker.getPopup().getContent();
+      assert.ok(popupContent.includes("speed:N/A"), "popup should show N/A for speed when not available");
+      assert.ok(popupContent.includes("heading:N/A"), "popup should show N/A for heading when not available");
+    });
+
+    it("should convert speed to mph when metric is false", () => {
+      const control = new LocateControl({
+        showPopup: true,
+        metric: false,
+        strings: {
+          popup: "{speed} {speedUnit}"
+        }
+      });
+      map.addControl(control);
+
+      control._event = {
+        latlng: { lat: 51.505, lng: -0.09 },
+        accuracy: 100,
+        speed: 10
+      };
+      control._drawMarker();
+
+      const popupContent = control._marker.getPopup().getContent();
+      assert.ok(popupContent.includes("22.4"), "popup should contain speed in mph");
+      assert.ok(popupContent.includes("mph"), "popup should contain mph unit");
     });
   });
 });

--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -867,8 +867,7 @@ describe("LocateControl", () => {
       assert.strictEqual(receivedData.altitude, "15.0");
       assert.ok(receivedData.distance);
       assert.ok(receivedData.unit);
-      assert.strictEqual(receivedData.speed, "19.8", "speed should be converted to km/h");
-      assert.strictEqual(receivedData.speedUnit, "km/h");
+      assert.strictEqual(receivedData.speed, "5.50", "speed should be raw m/s");
       assert.strictEqual(receivedData.heading, "270", "heading should be in degrees");
     });
 
@@ -876,7 +875,7 @@ describe("LocateControl", () => {
       const control = new LocateControl({
         showPopup: true,
         strings: {
-          popup: "{speed} {speedUnit} heading {heading}°"
+          popup: "{speed} m/s heading {heading}°"
         }
       });
       map.addControl(control);
@@ -890,8 +889,8 @@ describe("LocateControl", () => {
       control._drawMarker();
 
       const popupContent = control._marker.getPopup().getContent();
-      assert.ok(popupContent.includes("36.0"), "popup should contain speed in km/h");
-      assert.ok(popupContent.includes("km/h"), "popup should contain speed unit");
+      assert.ok(popupContent.includes("10.00"), "popup should contain raw speed in m/s");
+      assert.ok(popupContent.includes("m/s"), "popup should contain speed unit label");
       assert.ok(popupContent.includes("90"), "popup should contain heading");
     });
 
@@ -915,12 +914,12 @@ describe("LocateControl", () => {
       assert.ok(popupContent.includes("heading:N/A"), "popup should show N/A for heading when not available");
     });
 
-    it("should convert speed to mph when metric is false", () => {
+    it("should provide raw speed regardless of metric setting", () => {
       const control = new LocateControl({
         showPopup: true,
         metric: false,
         strings: {
-          popup: "{speed} {speedUnit}"
+          popup: "{speed}"
         }
       });
       map.addControl(control);
@@ -933,8 +932,7 @@ describe("LocateControl", () => {
       control._drawMarker();
 
       const popupContent = control._marker.getPopup().getContent();
-      assert.ok(popupContent.includes("22.4"), "popup should contain speed in mph");
-      assert.ok(popupContent.includes("mph"), "popup should contain mph unit");
+      assert.ok(popupContent.includes("10.00"), "speed should be raw m/s regardless of metric setting");
     });
   });
 });

--- a/src/L.Control.Locate.d.ts
+++ b/src/L.Control.Locate.d.ts
@@ -18,6 +18,8 @@ export interface StringsOptions {
   text?: string | undefined;
   metersUnit?: string | undefined;
   feetUnit?: string | undefined;
+  kmhUnit?: string | undefined;
+  mphUnit?: string | undefined;
   popup?: string | undefined;
   outsideMapBoundsMsg?: string | undefined;
 }

--- a/src/L.Control.Locate.d.ts
+++ b/src/L.Control.Locate.d.ts
@@ -18,8 +18,6 @@ export interface StringsOptions {
   text?: string | undefined;
   metersUnit?: string | undefined;
   feetUnit?: string | undefined;
-  kmhUnit?: string | undefined;
-  mphUnit?: string | undefined;
   popup?: string | undefined;
   outsideMapBoundsMsg?: string | undefined;
 }

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -8,8 +8,6 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
 import { Control, Marker, setOptions, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
 
 const METERS_TO_FEET = 3.2808399;
-const MS_TO_KMH = 3.6;
-const MS_TO_MPH = 2.2369363;
 
 /**
  * Add one or more CSS classes to an element.
@@ -372,8 +370,6 @@ const LocateControl = Control.extend({
       title: "Show me where I am",
       metersUnit: "meters",
       feetUnit: "feet",
-      kmhUnit: "km/h",
-      mphUnit: "mph",
       popup: "You are within {distance} {unit} from this point",
       outsideMapBoundsMsg: "You seem located outside the boundaries of the map"
     },
@@ -802,23 +798,18 @@ const LocateControl = Control.extend({
     let distance;
     let unit;
     let altitude;
-    let speed;
-    let speedUnit;
     if (this.options.metric) {
       distance = accuracy.toFixed(0);
       unit = this.options.strings.metersUnit;
       altitude = this._event?.altitude != null ? this._event.altitude.toFixed(1) : "N/A";
-      speed = this._event?.speed != null ? (this._event.speed * MS_TO_KMH).toFixed(1) : "N/A";
-      speedUnit = this.options.strings.kmhUnit;
     } else {
       distance = (accuracy * METERS_TO_FEET).toFixed(0);
       unit = this.options.strings.feetUnit;
       altitude = this._event?.altitude != null ? (this._event.altitude * METERS_TO_FEET).toFixed(1) : "N/A";
-      speed = this._event?.speed != null ? (this._event.speed * MS_TO_MPH).toFixed(1) : "N/A";
-      speedUnit = this.options.strings.mphUnit;
     }
 
-    // Format heading (always in degrees, unit-independent)
+    // Speed in m/s (raw value from Geolocation API), heading in degrees
+    const speed = this._event?.speed != null ? this._event.speed.toFixed(2) : "N/A";
     const heading = this._event?.heading != null ? this._event.heading.toFixed(0) : "N/A";
 
     // Collect template data
@@ -829,7 +820,6 @@ const LocateControl = Control.extend({
       lng: latlng.lng.toFixed(6),
       altitude,
       speed,
-      speedUnit,
       heading
     };
 

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -8,6 +8,8 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
 import { Control, Marker, setOptions, DivIcon, LayerGroup, Circle, DomEvent, Util as LeafletUtil } from "leaflet";
 
 const METERS_TO_FEET = 3.2808399;
+const MS_TO_KMH = 3.6;
+const MS_TO_MPH = 2.2369363;
 
 /**
  * Add one or more CSS classes to an element.
@@ -370,6 +372,8 @@ const LocateControl = Control.extend({
       title: "Show me where I am",
       metersUnit: "meters",
       feetUnit: "feet",
+      kmhUnit: "km/h",
+      mphUnit: "mph",
       popup: "You are within {distance} {unit} from this point",
       outsideMapBoundsMsg: "You seem located outside the boundaries of the map"
     },
@@ -798,15 +802,24 @@ const LocateControl = Control.extend({
     let distance;
     let unit;
     let altitude;
+    let speed;
+    let speedUnit;
     if (this.options.metric) {
       distance = accuracy.toFixed(0);
       unit = this.options.strings.metersUnit;
       altitude = this._event?.altitude != null ? this._event.altitude.toFixed(1) : "N/A";
+      speed = this._event?.speed != null ? (this._event.speed * MS_TO_KMH).toFixed(1) : "N/A";
+      speedUnit = this.options.strings.kmhUnit;
     } else {
       distance = (accuracy * METERS_TO_FEET).toFixed(0);
       unit = this.options.strings.feetUnit;
       altitude = this._event?.altitude != null ? (this._event.altitude * METERS_TO_FEET).toFixed(1) : "N/A";
+      speed = this._event?.speed != null ? (this._event.speed * MS_TO_MPH).toFixed(1) : "N/A";
+      speedUnit = this.options.strings.mphUnit;
     }
+
+    // Format heading (always in degrees, unit-independent)
+    const heading = this._event?.heading != null ? this._event.heading.toFixed(0) : "N/A";
 
     // Collect template data
     const data = {
@@ -814,7 +827,10 @@ const LocateControl = Control.extend({
       unit,
       lat: latlng.lat.toFixed(6),
       lng: latlng.lng.toFixed(6),
-      altitude
+      altitude,
+      speed,
+      speedUnit,
+      heading
     };
 
     // Generate popup text


### PR DESCRIPTION
With this the following placeholders are now available in `strings.popup`:

- `{speed}` – raw value in m/s as provided by the Geolocation API, "N/A" if unavailable
- `{heading}` – degrees 0–360, "N/A" if unavailable

Unit conversion is left to the consumer, e.g. via the function form of `strings.popup`. The default popup template is unchanged.

<img width="403" height="323" alt="signal-2026-03-04-220739_002" src="https://github.com/user-attachments/assets/6458c013-3588-4cd9-965f-9d49bc44ef58" />

*The screenshot is no longer up to date. We now display m/s instead of km/h.*

It resolves #345 and is a good addition to PR #398.

Demo: https://kristjanesperanto.github.io/leaflet-locatecontrol/demo/esm/
*Use a mobile and the second locate control at the bottom*.