### PR TITLE
docs: fix onLocationError option description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,4 +110,4 @@ Thanks to @brendanheywood for the updates!
 
 ---
 
-*Changes prior to v0.46.0 are not documented here. See the [full commit history](https://github.com/domoritz/leaflet-locatecontrol/commits/gh-pages/) for details.*
+_Changes prior to v0.46.0 are not documented here. See the [full commit history](https://github.com/domoritz/leaflet-locatecontrol/commits/gh-pages/) for details._

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Possible options are listed in the following table. More details are [in the cod
 | `circlePadding` | `array`  | Padding around the accuracy circle. | `[0, 0]` |
 | `createButtonCallback` | `function`  | This callback can be used in case you would like to override button creation behavior. | see code |
 | `getLocationBounds` | `function`  | This callback can be used to override the viewport tracking behavior. | see code |
-| `onLocationError` | `function`  | This even is called when the user's location is outside the bounds set on the map. | see code |
+| `onLocationError` | `function`  | Called on location errors. Receives the error and the control instance. | see code |
 | `metric` | `boolean` | Use metric units. | `true` |
 | `onLocationOutsideMapBounds` | `function`  | Called when the user's location is outside the bounds set on the map. Called repeatedly when the user's location changes. | see code |
 | `showPopup` | `boolean`  | Display a pop-up when the user click on the inner marker. | `true` |


### PR DESCRIPTION
The description incorrectly stated the callback fires "when the user's location is outside the bounds set on the map". That looks like a copy-paste error from an old rewrite (commit 8878b8a) where the option descriptions were shifted by one row in the table.

The callback actually fires on location errors (not timeouts).