### PR TITLE
fix: unbind link listeners on remove

### DIFF
--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -361,6 +361,32 @@ describe("LocateControl", () => {
       // Control should be stopped
       assert.strictEqual(control._active, false);
     });
+
+    it("should not accumulate link listeners for external button callbacks", () => {
+      const link = document.createElement("a");
+      const icon = document.createElement("span");
+      link.setAttribute("href", "#");
+      link.append(icon);
+      document.body.append(link);
+
+      const control = new LocateControl({
+        createButtonCallback() {
+          return { link, icon };
+        }
+      });
+
+      map.addControl(control);
+      const clickSpy = mock.method(control, "_onClick", () => {});
+
+      link.dispatchEvent(new Event("click", { bubbles: true, cancelable: true }));
+      assert.strictEqual(clickSpy.mock.calls.length, 1);
+
+      map.removeControl(control);
+      map.addControl(control);
+
+      link.dispatchEvent(new Event("click", { bubbles: true, cancelable: true }));
+      assert.strictEqual(clickSpy.mock.calls.length, 2);
+    });
   });
 
   describe("CSS state", () => {

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -420,12 +420,15 @@ const LocateControl = Control.extend({
     this._link = linkAndIcon.link;
     this._icon = linkAndIcon.icon;
 
-    this._link.addEventListener("click", (ev) => {
+    this._linkClickHandler = (ev) => {
       ev.stopPropagation();
       ev.preventDefault();
       this._onClick();
-    });
-    this._link.addEventListener("dblclick", (ev) => ev.stopPropagation());
+    };
+    this._linkDblClickHandler = (ev) => ev.stopPropagation();
+
+    this._link.addEventListener("click", this._linkClickHandler);
+    this._link.addEventListener("dblclick", this._linkDblClickHandler);
 
     this._resetVariables();
 
@@ -438,6 +441,19 @@ const LocateControl = Control.extend({
    * Called when control is removed from the map.
    */
   onRemove() {
+    if (this._link && this._linkClickHandler) {
+      this._link.removeEventListener("click", this._linkClickHandler);
+    }
+    if (this._link && this._linkDblClickHandler) {
+      this._link.removeEventListener("dblclick", this._linkDblClickHandler);
+    }
+    if (this._map) {
+      this._map.off("unload", this._unload, this);
+    }
+
+    this._linkClickHandler = null;
+    this._linkDblClickHandler = null;
+
     this.stop();
   },
 


### PR DESCRIPTION
`onRemove` never cleaned up the `click`/`dblclick` listeners added in `onAdd`. With the default `createButtonCallback` this doesn't matter - the `<a>` element is thrown away when the control is removed. But when a custom callback returns a **persistent external element**, removing and re-adding the control stacks up handlers, so one click fires `_onClick` multiple times.

## Changes

Store both handlers as instance fields in `onAdd`, remove them in `onRemove`. Also moves the `unload` map-listener cleanup into `onRemove` (previously it only cleaned up after itself inside `_unload`).

Add a regression test that re-adds the control to the same external element and asserts `_onClick` fires exactly once per click.

Fixes #416