### PR TITLE
fix(compass): guard DeviceOrientationEvent lookup

### DIFF
--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -658,6 +658,31 @@ describe("LocateControl", () => {
       assert.strictEqual(spy.mock.callCount(), 0, "_onDeviceOrientation should not be called after rejection");
     });
 
+    it("should work when DeviceOrientationEvent global is undefined", async () => {
+      const originalWindowDeviceOrientationEvent = window.DeviceOrientationEvent;
+      const originalGlobalDeviceOrientationEvent = global.DeviceOrientationEvent;
+
+      try {
+        delete window.DeviceOrientationEvent;
+        delete global.DeviceOrientationEvent;
+
+        const control = new LocateControl({ showCompass: true });
+        map.addControl(control);
+        control._active = true;
+
+        await control._activateCompass();
+        assert.ok(["deviceorientation", "deviceorientationabsolute"].includes(control._compassEventName), "Should still bind orientation listener");
+
+        const event = new Event(control._compassEventName);
+        Object.defineProperty(event, "alpha", { value: 90 });
+        window.dispatchEvent(event);
+        assert.strictEqual(control._compassHeading, 270, "Should process orientation event without global constructor");
+      } finally {
+        window.DeviceOrientationEvent = originalWindowDeviceOrientationEvent;
+        global.DeviceOrientationEvent = originalGlobalDeviceOrientationEvent;
+      }
+    });
+
     it("should call _activateCompass from _activate", () => {
       const control = new LocateControl({ showCompass: true });
       map.addControl(control);

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -590,9 +590,11 @@ const LocateControl = Control.extend({
 
     const eventName = oriAbs ? "deviceorientationabsolute" : "deviceorientation";
 
-    if (DeviceOrientationEvent && typeof DeviceOrientationEvent.requestPermission === "function") {
+    const deviceOrientationEvent = window.DeviceOrientationEvent;
+
+    if (typeof deviceOrientationEvent !== "undefined" && typeof deviceOrientationEvent.requestPermission === "function") {
       try {
-        const permissionState = await DeviceOrientationEvent.requestPermission();
+        const permissionState = await deviceOrientationEvent.requestPermission();
         if (permissionState !== "granted") {
           return;
         }


### PR DESCRIPTION
In some environments, orientation events are present in `window` but the `DeviceOrientationEvent` constructor is not defined as a global - triggering a `ReferenceError` when the compass is activated. This seems to affect a subset of Firefox users on Linux (reported with Firefox 149).

The fix reads `DeviceOrientationEvent` safely via `window` instead of as a bare identifier, so the compass fails gracefully without breaking geolocation.

Includes a regression test for this case.

Closes #419