### PR TITLE
fix(compass): fix iOS heading in landscape mode

### DIFF
--- a/spec/L.Control.Locate.spec.js
+++ b/spec/L.Control.Locate.spec.js
@@ -595,6 +595,52 @@ describe("LocateControl", () => {
       assert.strictEqual(control._compassHeading, 270, "Should process orientation event (360 - 90)");
     });
 
+    it("should process iOS heading when webkitCompassHeading is 0", () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      control._onDeviceOrientation({ webkitCompassHeading: 0, alpha: null });
+
+      assert.strictEqual(control._compassHeading, 0, "Should treat 0 as a valid iOS heading");
+    });
+
+    it("should compensate iOS heading with screen orientation angle", () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      const originalOrientation = window.screen?.orientation;
+
+      try {
+        window.screen.orientation = { angle: 90, type: "landscape-primary" };
+
+        control._onDeviceOrientation({ webkitCompassHeading: 90, alpha: null });
+
+        assert.strictEqual(control._compassHeading, 180, "Should apply screen angle compensation on iOS");
+      } finally {
+        window.screen.orientation = originalOrientation;
+      }
+    });
+
+    it("should fallback to zero screen angle when orientation is unavailable", () => {
+      const control = new LocateControl({ showCompass: true });
+      map.addControl(control);
+      control._active = true;
+
+      const originalOrientation = window.screen?.orientation;
+
+      try {
+        window.screen.orientation = undefined;
+
+        control._onDeviceOrientation({ webkitCompassHeading: 90, alpha: null });
+
+        assert.strictEqual(control._compassHeading, 90, "Should keep iOS heading unchanged without screen orientation");
+      } finally {
+        window.screen.orientation = originalOrientation;
+      }
+    });
+
     it("should prefer deviceorientationabsolute when available", async () => {
       window.ondeviceorientationabsolute = null;
 

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -57,6 +57,14 @@ global.DeviceOrientationEvent = class DeviceOrientationEvent extends Event {
   }
 };
 
+// Mock screen.orientation (not provided by happy-dom as a global)
+global.screen = {
+  orientation: {
+    angle: 0,
+    type: "portrait-primary"
+  }
+};
+
 // Mock requestAnimationFrame
 global.requestAnimationFrame = (callback) => {
   return setTimeout(callback, 16);

--- a/src/L.Control.Locate.js
+++ b/src/L.Control.Locate.js
@@ -906,9 +906,11 @@ const LocateControl = Control.extend({
       return;
     }
 
-    if (e.webkitCompassHeading) {
-      // iOS
-      this._setCompassHeading(e.webkitCompassHeading);
+    if (e.webkitCompassHeading != null) {
+      // iOS: webkitCompassHeading is relative to device top.
+      // Compensate using current screen orientation when available.
+      const screenAngle = window.screen?.orientation?.angle ?? 0;
+      this._setCompassHeading((e.webkitCompassHeading + screenAngle) % 360);
     } else if (e.alpha !== null) {
       // Android
       this._setCompassHeading(360 - e.alpha);


### PR DESCRIPTION
After working on #420 I had another look at #262 and think we can go with this fix.

On iOS, `webkitCompassHeading` is relative to the physical device top, not the screen. In landscape mode the compass arrow therefore points in the wrong direction. This adds `screen.orientation.angle` as a compensation offset (iOS 16.4+). On older devices the fallback is 0, which is no worse than before.

Two smaller things fixed along the way:

- `webkitCompassHeading === 0` (due north) was silently dropped by a falsy check - changed to `!= null`.
- The result is now normalized with `% 360`.

Regression tests are included.

I don't have an iOS device to test on. The formula matches the workaround posted by the original reporter in #262, so I'm fairly confident it's correct and good to go.


Closes #262